### PR TITLE
Adds support for nesting bodytemplates and improves tests to better cover error-handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Terraform Provider for LogDNA
 
 [![CircleCI](https://circleci.com/gh/logdna/terraform-provider-logdna/tree/master.svg?style=svg)](https://app.circleci.com/pipelines/github/logdna/terraform-provider-logdna)
-[![Coverage Status](https://coveralls.io/repos/github/logdna/terraform-provider-logdna/badge.svg?branch=main)](https://coveralls.io/github/logdna/terraform-provider-logdna?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/logdna/terraform-provider-logdna/badge.svg)](https://coveralls.io/github/logdna/terraform-provider-logdna)
 
 🚧 In public beta 🚧
 

--- a/docs/resources/logdna_view.md
+++ b/docs/resources/logdna_view.md
@@ -108,7 +108,7 @@ _Note:_ At least one of the following properties: `apps`, `hosts`, `levels`, `qu
 
 `webhook_channel` supports the following arguments:
 
-- `bodytemplate`: _(Optional)_ JSON Object for the body of the webhook, type Map of _strings_
+- `bodytemplate`: _(Optional)_ JSON formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string. Type _string_
 - `headers`: _(Optional)_ Key-value pair for webhook request headers and header values, type Map of _strings_
 - `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached, type _string_ (**Default: "false"**)
 - `method`: _(Optional)_ Method used for the webhook request, type _string_ (**Default: "POST"**)

--- a/examples/view_with_email_pagerduty_and_webhook_alerts.tf
+++ b/examples/view_with_email_pagerduty_and_webhook_alerts.tf
@@ -7,7 +7,7 @@ resource "logdna_view" "my_view" {
   categories = ["Demo1", "Demo2"]
   hosts      = ["host1", "host2"]
   levels     = ["fatal", "critical"]
-  name       = "Email Pagerduty and Webhook Alerts"
+  name       = "Email PagerDuty and Webhook Alerts"
   query      = "test"
   tags       = ["host1", "host2"]
   email_channel {
@@ -27,14 +27,14 @@ resource "logdna_view" "my_view" {
     triggerlimit    = 15
   }
   webhook_channel {
-    bodytemplate = {
-      hello = "test1"
-      test  = "test2"
-    }
     headers = {
       hello = "test3"
       test  = "test2"
     }
+    bodytemplate = jsonencode({
+      hello = "test1"
+      test  = "test2"
+    })
     immediate       = "false"
     method          = "post"
     terminal        = "true"

--- a/examples/view_with_webhook_alert.tf
+++ b/examples/view_with_webhook_alert.tf
@@ -1,0 +1,37 @@
+provider "logdna" {
+  servicekey = "Your service key goes here"
+}
+
+resource "logdna_view" "my_view" {
+  apps       = ["app1", "app2"]
+  categories = ["Demo1", "Demo2"]
+  hosts      = ["host1", "host2"]
+  levels     = ["fatal", "critical"]
+  name       = "Webhook Alert"
+  query      = "test"
+  tags       = ["host1", "host2"]
+  webhook_channel {
+    headers = {
+      hello = "test3"
+      test  = "test2"
+    }
+    bodytemplate = jsonencode({
+      fields = {
+        description = "{{ matches }} matches found for {{ name }}"
+        issuetype = {
+          name = "Bug"
+        }
+        project = {
+          key = "test"
+        },
+        summary = "Alert From {{ name }}"
+      }
+    })
+    immediate       = "false"
+    method          = "post"
+    url             = "https://yourwebhook/endpoint"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module example.com/terraform-provider-logdna
+module github.com/logdna/terraform-provider-logdna
 
 go 1.14
 

--- a/logdna/client.go
+++ b/logdna/client.go
@@ -8,6 +8,12 @@ import (
 	"net/http"
 )
 
+// Client used to make HTTP requests to the configuration api
+type Client struct {
+	ServiceKey string
+	HTTPClient *http.Client
+}
+
 type viewPayload struct {
 	Apps     []string  `json:"apps,omitempty"`
 	Category []string  `json:"category,omitempty"`
@@ -50,16 +56,10 @@ type channelResponse struct {
 	Method          string            `json:"method,omitempty"`
 	Operator        string            `json:"operator,omitempty"`
 	Terminal        bool              `json:"terminal,omitempty"`
-	Triggerinterval int               `json:"triggerinterval,omitempty"`
-	Triggerlimit    int               `json:"triggerlimit,omitempty"`
+	TriggerInterval int               `json:"triggerinterval,omitempty"`
+	TriggerLimit    int               `json:"triggerlimit,omitempty"`
 	Timezone        string            `json:"timezone,omitempty"`
 	URL             string            `json:"url,omitempty"`
-}
-
-// Client used to make http requests to the configuration api
-type Client struct {
-	servicekey string
-	httpClient *http.Client
 }
 
 // MakeRequestView makes a request to the config-api and parses and returns the response
@@ -73,8 +73,8 @@ func MakeRequestView(c *Client, url string, urlsuffix string, method string, pay
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("servicekey", c.servicekey)
-	resp, err := c.httpClient.Do(req)
+	req.Header.Set("servicekey", c.ServiceKey)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf(`Error with view: %s`, err)
 	}

--- a/logdna/provider.go
+++ b/logdna/provider.go
@@ -8,9 +8,9 @@ import (
 )
 
 type config struct {
-	servicekey string
-	url        string
-	httpClient *http.Client
+	ServiceKey string
+	URL        string
+	HTTPClient *http.Client
 }
 
 // Provider sets the schema to a servicekey and url and adds logdna_view as a resource
@@ -38,5 +38,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	servicekey := d.Get("servicekey").(string)
 	url := d.Get("url").(string)
 
-	return &config{servicekey: servicekey, url: url, httpClient: &http.Client{Timeout: 15 * time.Second}}, nil
+	return &config{ServiceKey: servicekey, URL: url, HTTPClient: &http.Client{Timeout: 15 * time.Second}}, nil
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"example.com/terraform-provider-logdna/logdna"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/logdna/terraform-provider-logdna/logdna"
 )
 
 func main() {


### PR DESCRIPTION
Updates resource_view code to support nesting body templates, updates docs to reflect these changes and adds an example config file.

Additionally fixes the badge on the README to reflect current coverage, updates the go.mod to point to Github and improves tests to better cover error-handling.

Ref: LOG-7689, LOG-7779
Semver: Patch