### PR TITLE
Convert terminal and immediate to booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ resource "logdna_alert" "my_alert" {
   }
 
   pagerduty_channel {
-    immediate       = "false"
+    immediate       = false
     key             = "Your PagerDuty API key goes here"
-    terminal        = "true"
+    terminal        = true
     triggerinterval = "15m"
     triggerlimit    = 15
   }
@@ -58,18 +58,18 @@ resource "logdna_view" "my_view" {
 
   email_channel {
     emails          = ["test@logdna.com"]
-    immediate       = "false"
+    immediate       = false
     operator        = "absence"
-    terminal        = "true"
+    terminal        = true
     timezone        = "Pacific/Samoa"
     triggerinterval = "15m"
     triggerlimit    = 15
   }
 
   pagerduty_channel {
-    immediate       = "false"
+    immediate       = false
     key             = "Your PagerDuty API key goes here"
-    terminal        = "true"
+    terminal        = true
     triggerinterval = "15m"
     triggerlimit    = 15
   }
@@ -83,9 +83,9 @@ resource "logdna_view" "my_view" {
       hello = "test3"
       test  = "test2"
     }
-    immediate       = "false"
+    immediate       = false
     method          = "post"
-    terminal        = "true"
+    terminal        = true
     triggerinterval = "15m"
     triggerlimit    = 15
     url             = "https://yourwebhook/endpoint"

--- a/docs/resources/logdna_alert.md
+++ b/docs/resources/logdna_alert.md
@@ -16,11 +16,11 @@ resource "logdna_alert" "my_alert" {
   name = "My Preset Alert via Terraform"
   email_channel {
     emails          = ["test@logdna.com"]
-    immediate       = "false"
+    immediate       = false
     operator        = "presence"
     triggerlimit    = 15
     triggerinterval = "15m"
-    terminal        = "true"
+    terminal        = true
     timezone        = "Pacific/Samoa"
   }
 }
@@ -39,18 +39,18 @@ resource "logdna_alert" "my_alert" {
   name = "Terraform Multi-channel Preset Alert"
   email_channel {
     emails          = ["test@logdna.com"]
-    immediate       = "false"
+    immediate       = false
     operator        = "absence"
-    terminal        = "true"
+    terminal        = true
     timezone        = "Pacific/Samoa"
     triggerinterval = "15m"
     triggerlimit    = 15
   }
 
   pagerduty_channel {
-    immediate       = "true"
+    immediate       = true
     key             = "Your PagerDuty API key goes here"
-    terminal        = "true"
+    terminal        = true
     triggerinterval = "15m"
     triggerlimit    = 15
   }
@@ -63,9 +63,9 @@ resource "logdna_alert" "my_alert" {
       "Authentication" = "auth_header_value"
       "HeaderTwo"      = "ValueTwo"
     }
-    immediate       = "false"
+    immediate       = false
     method          = "post"
-    terminal        = "true"
+    terminal        = true
     triggerinterval = "15m"
     triggerlimit    = 15
     url             = "https://yourwebhook/endpoint"
@@ -84,9 +84,9 @@ The following arguments are supported:
 `email_channel` supports the following arguments:
 
 - `emails`: _(Required)_ An array of email addresses (each email is of type _string_) to notify in the Alert
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
+- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _bool_ (**Default: false**)
 - `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
+- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _bool_ (**Default: true**)
 - `timezone`: _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), type _string_
 - `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
 - `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
@@ -95,10 +95,10 @@ The following arguments are supported:
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
+- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _bool_ (**Default: false**)
 - `key`: _(Required)_ PagerDuty service key, type _string_
 - `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
+- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _bool_ (**Default: true**)
 - `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
 - `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
 
@@ -108,10 +108,10 @@ The following arguments are supported:
 
 - `bodytemplate`: _(Optional)_ JSON formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string. Type _string_
 - `headers`: _(Optional)_ Key-value pair for webhook request headers and header values, type Map of _strings_
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
+- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _bool_ (**Default: false**)
 - `method`: _(Optional)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`. Type _string_ (**Default: "post"**)
 - `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
+- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _bool_ (**Default: true**)
 - `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
 - `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
 - `url`: _(Required)_ URL of the webhook, type _string_

--- a/docs/resources/logdna_view.md
+++ b/docs/resources/logdna_view.md
@@ -35,9 +35,9 @@ resource "logdna_view" "my_view" {
 
   email_channel {
     emails          = ["test@logdna.com"]
-    immediate       = "false"
+    immediate       = false
     operator        = "absence"
-    terminal        = "true"
+    terminal        = true
     timezone        = "Pacific/Samoa"
     triggerinterval = "15m"
     triggerlimit    = 15
@@ -58,9 +58,9 @@ resource "logdna_view" "my_view" {
       "Authentication" = "auth_header_value"
       "HeaderTwo"      = "ValueTwo"
     }
-    immediate       = "false"
+    immediate       = false
     method          = "post"
-    terminal        = "true"
+    terminal        = true
     triggerinterval = "15m"
     triggerlimit    = 15
     url             = "https://yourwebhook/endpoint"
@@ -75,7 +75,7 @@ The following arguments are supported:
 _Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, `levels`, `query`, `tags` must be specified to create a View.
 
 - `apps`: _(Optional)_ Array of names of apps (each app is of type _string_) to filter the View by
-- `categories`: _(Optional)_ Array of existing category names (each category is of type _string_) this View should be nested under. _Note: If the category does not exist, the View will by default be created in uncategorized_
+- `categories`: _(Optional)_ Array of existing category names (each category is of type _string_) this View should be nested under. _Note: If categories are not provided, the View will by default be created in uncategorized. Additionally, a user needs to have created categories in the account of interest before they are referenced in the Terraform configuration_ 
 - `hosts`: _(Optional)_ Array of names of hosts (each host is of type _string_) to filter the View by
 - `levels`: _(Optional)_ Array of names of levels (each level is of type _string_) to filter the View by
 - `name`: _(Required)_ Name this View will be given, type _string_
@@ -87,9 +87,9 @@ _Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, 
 `email_channel` supports the following arguments:
 
 - `emails`: _(Required)_ An array of email addresses (each email is of type _string_) to notify in the Alert
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
+- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _bool_ (**Default: false**)
 - `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
+- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _bool_ (**Default: true**)
 - `timezone`: _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), type _string_
 - `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
 - `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
@@ -98,10 +98,10 @@ _Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, 
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
+- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _bool_ (**Default: false**)
 - `key`: _(Required)_ PagerDuty service key, type _string_
 - `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
+- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _bool_ (**Default: true**)
 - `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
 - `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
 
@@ -111,10 +111,10 @@ _Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, 
 
 - `bodytemplate`: _(Optional)_ JSON formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string. Type _string_
 - `headers`: _(Optional)_ Key-value pair for webhook request headers and header values, type Map of _strings_
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
+- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _bool_ (**Default: false**)
 - `method`: _(Optional)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`. Type _string_ (**Default: "post"**)
 - `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
+- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _bool_ (**Default: true**)
 - `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
 - `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
 - `url`: _(Required)_ URL of the webhook, type _string_

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/logdna/terraform-provider-logdna
 
 go 1.14
 
-require github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4
+require (
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.4
+	github.com/stretchr/testify v1.4.0
+)

--- a/logdna/client.go
+++ b/logdna/client.go
@@ -128,19 +128,19 @@ func MakeRequestView(c *Client, url string, urlsuffix string, method string, pay
 
 // CreateAlert creates a Preset Alert with the provided payload
 func (c *Client) CreateAlert(url string, payload ViewPayload) (string, error) {
-	result, err := MakeRequestAlert(c, url, "/v1/config/alert", "POST", payload)
+	result, err := MakeRequestAlert(c, url, "/v1/config/presetalert", "POST", payload)
 	return result, err
 }
 
 // UpdateAlert updates a Preset Alert with the provided presetID and payload
 func (c *Client) UpdateAlert(url string, presetID string, payload ViewPayload) error {
-	_, err := MakeRequestAlert(c, url, "/v1/config/alert/"+presetID, "PUT", payload)
+	_, err := MakeRequestAlert(c, url, "/v1/config/presetalert/"+presetID, "PUT", payload)
 	return err
 }
 
 // DeleteAlert deletes an alert with the provided presetID
 func (c *Client) DeleteAlert(url, presetID string) error {
-	_, err := MakeRequestAlert(c, url, "/v1/config/alert/"+presetID, "DELETE", ViewPayload{})
+	_, err := MakeRequestAlert(c, url, "/v1/config/presetalert/"+presetID, "DELETE", ViewPayload{})
 	return err
 }
 

--- a/logdna/resource_alert.go
+++ b/logdna/resource_alert.go
@@ -73,7 +73,6 @@ func resourceAlert() *schema.Resource {
 		ReadContext:   resourceAlertRead,
 		UpdateContext: resourceAlertUpdate,
 		DeleteContext: resourceAlertDelete,
-
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -92,16 +91,18 @@ func resourceAlert() *schema.Resource {
 							},
 						},
 						"immediate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"operator": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"terminal": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
 						},
 						"timezone": {
 							Type:     schema.TypeString,
@@ -131,8 +132,9 @@ func resourceAlert() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"immediate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"key": {
 							Type:     schema.TypeString,
@@ -143,8 +145,9 @@ func resourceAlert() *schema.Resource {
 							Optional: true,
 						},
 						"terminal": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"triggerinterval": {
 							Type:     schema.TypeString,
@@ -181,8 +184,9 @@ func resourceAlert() *schema.Resource {
 							Optional: true,
 						},
 						"immediate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"method": {
 							Type:     schema.TypeString,
@@ -193,8 +197,9 @@ func resourceAlert() *schema.Resource {
 							Optional: true,
 						},
 						"terminal": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"triggerinterval": {
 							Type:     schema.TypeString,

--- a/logdna/resource_alert_test.go
+++ b/logdna/resource_alert_test.go
@@ -15,11 +15,12 @@ func TestAlert_expectInvalidURLError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAlertInvalidURL(),
-				ExpectError: regexp.MustCompile("Error: Error with alert: Post \"http://api.logdna.co/v1/config/alert\": dial tcp: lookup api.logdna.co on 127.0.0.11:53: no such host"),
+				ExpectError: regexp.MustCompile("Error: Error with alert: Post \"http://api.logdna.co/v1/config/presetalert\": dial tcp: lookup api.logdna.co on 127.0.0.11:53: no such host"),
 			},
 		},
 	})
 }
+
 func TestAlert_expectInvalidJSONError(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
@@ -50,7 +51,7 @@ func TestAlert_expectImmediateError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAlertConfigImmediateError(),
-				ExpectError: regexp.MustCompile(`\"channels\[0\].immediate\" must be \[false\]. \"channels\[0]\.immediate\" must be a boolean`),
+				ExpectError: regexp.MustCompile(`Inappropriate value for attribute "immediate": a bool is required`),
 			},
 		},
 	})
@@ -294,7 +295,7 @@ func TestAlertBulkChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerlimit", "15"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "1"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.%", "6"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.immediate", "true"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.immediate", "false"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.key", "Your PagerDuty API key goes here"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.operator", ""),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.terminal", "true"),
@@ -327,18 +328,18 @@ func testAlertConfigMultipleChannelsInvalidJSON() string {
 		name = "test"
 		email_channel {
 		  emails          = ["test@logdna.com"]
-		  immediate       = "false"
+		  immediate       = false
 		  operator        = "absence"
-		  terminal        = "true"
+		  terminal        = true
 		  timezone        = "Pacific/Samoa"
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
 
 		pagerduty_channel {
-		  immediate       = "false"
+		  immediate       = false
 		  key             = "Your PagerDuty API key goes here"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -349,10 +350,10 @@ func testAlertConfigMultipleChannelsInvalidJSON() string {
 			test  = "test2"
 		  }
 		  bodytemplate = "{\"test\": }"
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "post"
 		  url             = "https://yourwebhook/endpoint"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -368,9 +369,9 @@ func testAlertConfigTriggerIntervalError() string {
         name = "test"
         email_channel {
           emails          = ["test@logdna.com"]
-          immediate       = "false"
+          immediate       = false
           operator        = "absence"
-          terminal        = "true"
+          terminal        = true
           timezone        = "Pacific/Samoa"
           triggerinterval = "17m"
           triggerlimit    = 15
@@ -386,9 +387,9 @@ func testAlertConfigInvalidPagerDutyTriggerLimitError() string {
       resource "logdna_alert" "new" {
         name = "test"
 		pagerduty_channel {
-			immediate       = "false"
+			immediate       = false
 			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 0
 		}
@@ -406,7 +407,7 @@ func testAlertConfigImmediateError() string {
           emails          = ["test@logdna.com"]
           immediate       = "no"
           operator        = "absence"
-          terminal        = "true"
+          terminal        = true
           timezone        = "Pacific/Samoa"
           triggerinterval = "15m"
           triggerlimit    = 15
@@ -426,10 +427,10 @@ func testAlertConfigURLError() string {
 			hello = "test3"
 			test  = "test2"
 		  }
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "post"
 		  url             = "this is not a valid url"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -448,10 +449,10 @@ func testAlertConfigMethodError() string {
 			hello = "test3"
 			test  = "test2"
 		  }
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "false"
 		  url             = "http://yourwebhook/test"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -485,11 +486,11 @@ func testAlertConfigEmailTriggerLimitError() string {
 		name = "test"
 		email_channel {
 			emails          = ["test@logdna.com"]
-			immediate       = "false"
+			immediate       = false
 			operator        = "presence"
 			triggerlimit    = 0
 			triggerinterval = "15m"
-			terminal        = "true"
+			terminal        = true
 			timezone        = "Pacific/Samoa"
 		}
 	}`, servicekey)
@@ -503,9 +504,9 @@ func testAlertConfigPagerDutyTriggerLimitError() string {
 	resource "logdna_alert" "new" {
 		name = "test"
 		pagerduty_channel {
-			immediate       = "false"
+			immediate       = false
 			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 0
 		}
@@ -524,10 +525,10 @@ func testAlertConfigWebhookTriggerLimitError() string {
 			  hello = "test3"
 			  test  = "test2"
 			}
-			immediate       = "false"
+			immediate       = false
 			method          = "post"
 			url             = "https://yourwebhook/endpoint"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 0
 		}
@@ -542,9 +543,9 @@ func testAlertConfigMissingEmails() string {
 	resource "logdna_alert" "new" {
 		name     = "test"
 		email_channel {
-			immediate       = "false"
+			immediate       = false
 			operator        = "absence"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 15
 			timezone        = "Pacific/Samoa"
@@ -560,8 +561,8 @@ func testAlertConfigMissingKey() string {
 	resource "logdna_alert" "new" {
 		name     = "test"
 		pagerduty_channel {
-			immediate       = "false"
-			terminal        = "true"
+			immediate       = false
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 15
 		}
@@ -603,11 +604,11 @@ func testAlertConfigBasic(name string) string {
 		name = "%s"
 		email_channel {
 			emails          = ["test@logdna.com"]
-			immediate       = "false"
+			immediate       = false
 			operator        = "presence"
 			triggerlimit    = 15
 			triggerinterval = "15m"
-			terminal        = "true"
+			terminal        = true
 			timezone        = "Pacific/Samoa"
 		}
 	}`, servicekey, name)
@@ -622,17 +623,13 @@ func testAlertConfigBulkChannels(name string) string {
 		name = "%s"
 		email_channel {
 			emails          = ["test@logdna.com"]
-			immediate       = "false"
 			operator        = "absence"
-			terminal        = "true"
 			timezone        = "Pacific/Samoa"
 			triggerinterval = "15m"
 			triggerlimit    = 15
 		}
 		pagerduty_channel {
-			immediate       = "true"
 			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
 			triggerinterval = "15m"
 			triggerlimit    = 15
 		}

--- a/logdna/resource_view.go
+++ b/logdna/resource_view.go
@@ -15,12 +15,12 @@ type Channel struct {
 	BodyTemplate    map[string]interface{} `json:"bodyTemplate,omitempty"`
 	Emails          []string               `json:"emails,omitempty"`
 	Headers         map[string]string      `json:"headers,omitempty"`
-	Immediate       string                 `json:"immediate,omitempty"`
+	Immediate       *bool                  `json:"immediate,omitempty"`
 	Integration     string                 `json:"integration,omitempty"`
 	Key             string                 `json:"key,omitempty"`
 	Method          string                 `json:"method,omitempty"`
 	Operator        string                 `json:"operator,omitempty"`
-	Terminal        string                 `json:"terminal,omitempty"`
+	Terminal        *bool                  `json:"terminal,omitempty"`
 	TriggerInterval string                 `json:"triggerinterval,omitempty"`
 	TriggerLimit    int                    `json:"triggerlimit,omitempty"`
 	Timezone        string                 `json:"timezone,omitempty"`
@@ -33,9 +33,9 @@ func buildChannels(emailChannels []interface{}, pagerDutyChannels []interface{},
 		i := emailChannel.(map[string]interface{})
 
 		emails := i["emails"].([]interface{})
-		immediate := i["immediate"].(string)
+		immediate := i["immediate"].(bool)
 		operator := i["operator"].(string)
-		terminal := i["terminal"].(string)
+		terminal := i["terminal"].(bool)
 		triggerInterval := i["triggerinterval"].(string)
 		triggerLimit := i["triggerlimit"].(int)
 		timezone := i["timezone"].(string)
@@ -48,10 +48,10 @@ func buildChannels(emailChannels []interface{}, pagerDutyChannels []interface{},
 
 		email := Channel{
 			Emails:          emailStrings,
-			Immediate:       immediate,
+			Immediate:       &immediate,
 			Integration:     "email",
 			Operator:        operator,
-			Terminal:        terminal,
+			Terminal:        &terminal,
 			TriggerInterval: triggerInterval,
 			TriggerLimit:    triggerLimit,
 			Timezone:        timezone,
@@ -63,19 +63,19 @@ func buildChannels(emailChannels []interface{}, pagerDutyChannels []interface{},
 	for _, pagerDutyChannel := range pagerDutyChannels {
 		i := pagerDutyChannel.(map[string]interface{})
 
-		immediate := i["immediate"].(string)
+		immediate := i["immediate"].(bool)
 		key := i["key"].(string)
 		operator := i["operator"].(string)
-		terminal := i["terminal"].(string)
+		terminal := i["terminal"].(bool)
 		triggerInterval := i["triggerinterval"].(string)
 		triggerLimit := i["triggerlimit"].(int)
 
 		pagerDuty := Channel{
-			Immediate:       immediate,
+			Immediate:       &immediate,
 			Integration:     "pagerduty",
 			Key:             key,
 			Operator:        operator,
-			Terminal:        terminal,
+			Terminal:        &terminal,
 			TriggerInterval: triggerInterval,
 			TriggerLimit:    triggerLimit,
 		}
@@ -88,10 +88,10 @@ func buildChannels(emailChannels []interface{}, pagerDutyChannels []interface{},
 
 		bodytemplate := i["bodytemplate"].(string)
 		headers := i["headers"].(map[string]interface{})
-		immediate := i["immediate"].(string)
+		immediate := i["immediate"].(bool)
 		method := i["method"].(string)
 		operator := i["operator"].(string)
-		terminal := i["terminal"].(string)
+		terminal := i["terminal"].(bool)
 		triggerInterval := i["triggerinterval"].(string)
 		triggerLimit := i["triggerlimit"].(int)
 		url := i["url"].(string)
@@ -104,14 +104,14 @@ func buildChannels(emailChannels []interface{}, pagerDutyChannels []interface{},
 
 		webhook := Channel{
 			Headers:         headersMap,
-			Immediate:       immediate,
+			Immediate:       &immediate,
 			Integration:     "webhook",
 			Operator:        operator,
 			Method:          method,
 			TriggerInterval: triggerInterval,
 			TriggerLimit:    triggerLimit,
 			URL:             url,
-			Terminal:        terminal,
+			Terminal:        &terminal,
 		}
 
 		if bodytemplate != "" {
@@ -297,16 +297,18 @@ func resourceView() *schema.Resource {
 							},
 						},
 						"immediate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"operator": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"terminal": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"timezone": {
 							Type:     schema.TypeString,
@@ -336,8 +338,9 @@ func resourceView() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"immediate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"key": {
 							Type:     schema.TypeString,
@@ -348,8 +351,9 @@ func resourceView() *schema.Resource {
 							Optional: true,
 						},
 						"terminal": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"triggerinterval": {
 							Type:     schema.TypeString,
@@ -386,8 +390,9 @@ func resourceView() *schema.Resource {
 							Optional: true,
 						},
 						"immediate": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"method": {
 							Type:     schema.TypeString,
@@ -398,8 +403,9 @@ func resourceView() *schema.Resource {
 							Optional: true,
 						},
 						"terminal": {
-							Type:     schema.TypeString,
+							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  true,
 						},
 						"triggerinterval": {
 							Type:     schema.TypeString,

--- a/logdna/resource_view_test.go
+++ b/logdna/resource_view_test.go
@@ -51,7 +51,7 @@ func TestView_expectImmediateError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testViewConfigImmediateError(),
-				ExpectError: regexp.MustCompile(`\"channels\[0\].immediate\" must be \[false\]. \"channels\[0]\.immediate\" must be a boolean`),
+				ExpectError: regexp.MustCompile(`Inappropriate value for attribute "immediate": a bool is required`),
 			},
 		},
 	})
@@ -401,8 +401,6 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 	levels4 := "warning"
 	host3 := "host3"
 	host4 := "host4"
-	category3 := "DEMO3"
-	category4 := "DEMO4"
 	tags3 := "tags3"
 	tags4 := "tags4"
 
@@ -454,7 +452,7 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testViewConfigBulkEmails(name2, query2, app3, app4, levels3, levels4, host3, host4, category3, category4, tags3, tags4),
+				Config: testViewConfigBulkEmails(name2, query2, app3, app4, levels3, levels4, host3, host4, category, category2, tags3, tags4),
 				Check: resource.ComposeTestCheckFunc(
 					testViewExists("logdna_view.new"),
 					resource.TestCheckResourceAttr("logdna_view.new", "name", name2),
@@ -463,9 +461,8 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app3),
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app4),
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", category3),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category4),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", category),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2), resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.0", "test@logdna.com"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.immediate", "false"),
@@ -508,10 +505,10 @@ func TestViewMultipleChannels(t *testing.T) {
 	app2 := "app2"
 	levels1 := "fatal"
 	levels2 := "critical"
-	host1 := "host1"
-	host2 := "host2"
 	category1 := "DEMO"
 	category2 := "DEMO2"
+	host1 := "host1"
+	host2 := "host2"
 	tags1 := "host1"
 	tags2 := "host2"
 
@@ -601,17 +598,17 @@ func testViewConfigMultipleChannelsInvalidJSON() string {
 		query = "test"
 		email_channel {
 		  emails          = ["test@logdna.com"]
-		  immediate       = "false"
+		  immediate       = false
 		  operator        = "absence"
-		  terminal        = "true"
+		  terminal        = true
 		  timezone        = "Pacific/Samoa"
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
 		pagerduty_channel {
-		  immediate       = "false"
+		  immediate       = false
 		  key             = "Your PagerDuty API key goes here"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -621,10 +618,10 @@ func testViewConfigMultipleChannelsInvalidJSON() string {
 			test  = "test2"
 		  }
 		  bodytemplate = "{\"test\": }"
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "post"
 		  url             = "https://yourwebhook/endpoint"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -641,9 +638,9 @@ func testViewConfigTriggerIntervalError() string {
         query = "test"
         email_channel {
           emails          = ["test@logdna.com"]
-          immediate       = "false"
+          immediate       = false
           operator        = "absence"
-          terminal        = "true"
+          terminal        = true
           timezone        = "Pacific/Samoa"
           triggerinterval = "17m"
           triggerlimit    = 15
@@ -663,7 +660,7 @@ func testViewConfigImmediateError() string {
           emails          = ["test@logdna.com"]
           immediate       = "no"
           operator        = "absence"
-          terminal        = "true"
+          terminal        = true
           timezone        = "Pacific/Samoa"
           triggerinterval = "15m"
           triggerlimit    = 15
@@ -684,10 +681,10 @@ func testViewConfigURLError() string {
 			hello = "test3"
 			test  = "test2"
 		  }
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "post"
 		  url             = "this is not a valid url"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -707,10 +704,10 @@ func testViewConfigMethodError() string {
 			hello = "test3"
 			test  = "test2"
 		  }
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "false"
 		  url             = "http://yourwebhook/test"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -807,9 +804,9 @@ func testViewConfigEmailTriggerLimitError() string {
 		query    = "test"
 		email_channel {
 			emails          = ["test@logdna.com"]
-			immediate       = "false"
+			immediate       = false
 			operator        = "absence"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 0
 			timezone        = "Pacific/Samoa"
@@ -826,9 +823,9 @@ func testViewConfigPagerDutyTriggerLimitError() string {
 		name     = "test"
 		query    = "test"
 		pagerduty_channel {
-			immediate       = "false"
+			immediate       = false
 			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 0
 		}
@@ -848,10 +845,10 @@ func testViewConfigWebhookTriggerLimitError() string {
 			  hello = "test3"
 			  test  = "test2"
 			}
-			immediate       = "false"
+			immediate       = false
 			method          = "post"
 			url             = "https://yourwebhook/endpoint"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 0
 		}
@@ -867,9 +864,9 @@ func testViewConfigMissingEmails() string {
 		name     = "test"
 		query    = "test"
 		email_channel {
-			immediate       = "false"
+			immediate       = false
 			operator        = "absence"
-			terminal        = "true"
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 15
 			timezone        = "Pacific/Samoa"
@@ -886,8 +883,8 @@ func testViewConfigMissingKey() string {
 		name     = "test"
 		query    = "test"
 		pagerduty_channel {
-			immediate       = "false"
-			terminal        = "true"
+			immediate       = false
+			terminal        = true
 			triggerinterval = "15m"
 			triggerlimit    = 15
 		}
@@ -938,33 +935,29 @@ func testViewConfigBulkEmails(name, query, app1, app2, levels1, levels2, host1, 
 		servicekey = "%s"
 	}
 
-  resource "logdna_view" "new" {
-	name     = "%s"
-	query    = "%s"
-	apps     = ["%s", "%s"]
-	levels   = ["%s", "%s"]
-	hosts    = ["%s", "%s"]
-	categories = ["%s", "%s"]
-	tags     = ["%s", "%s"]
-	email_channel {
-	  emails          = ["test@logdna.com"]
-	  immediate       = "false"
-	  operator        = "absence"
-	  terminal        = "true"
-	  triggerinterval = "15m"
-	  triggerlimit    = 15
-	  timezone        = "Pacific/Samoa"
-	}
-	email_channel {
-	  emails          = ["test@logdna.com"]
-	  immediate       = "false"
-	  operator        = "absence"
-	  terminal        = "true"
-	  timezone        = "Pacific/Samoa"
-	  triggerlimit    = 15
-	  triggerinterval = "15m"
-	}
-  }`, servicekey, name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2)
+	resource "logdna_view" "new" {
+		name     = "%s"
+		query    = "%s"
+		apps     = ["%s", "%s"]
+		levels   = ["%s", "%s"]
+		hosts    = ["%s", "%s"]
+		categories = ["%s", "%s"]
+		tags     = ["%s", "%s"]
+		email_channel {
+			emails          = ["test@logdna.com"]
+			operator        = "absence"
+			triggerinterval = "15m"
+			triggerlimit    = 15
+			timezone        = "Pacific/Samoa"
+		}
+		email_channel {
+			emails          = ["test@logdna.com"]
+			operator        = "absence"
+			timezone        = "Pacific/Samoa"
+			triggerlimit    = 15
+			triggerinterval = "15m"
+		}
+	}`, servicekey, name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2)
 }
 
 func testViewConfigMultipleChannels(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2 string) string {
@@ -990,9 +983,9 @@ func testViewConfigMultipleChannels(name, query, app1, app2, levels1, levels2, h
 		  triggerlimit    = 15
 		}
 		pagerduty_channel {
-		  immediate       = "false"
+		  immediate       = false
 		  key             = "Your PagerDuty API key goes here"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
@@ -1013,14 +1006,14 @@ func testViewConfigMultipleChannels(name, query, app1, app2, levels1, levels2, h
 				summary = "Alert From {{ name }}"
 		   }
 		  })
-		  immediate       = "false"
+		  immediate       = false
 		  method          = "post"
 		  url             = "https://yourwebhook/endpoint"
-		  terminal        = "true"
+		  terminal        = true
 		  triggerinterval = "15m"
 		  triggerlimit    = 15
 		}
-	  }`, servicekey, name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2)
+	}`, servicekey, name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2)
 }
 
 func testViewExists(n string) resource.TestCheckFunc {


### PR DESCRIPTION
Converts terminal and immediate to booleans. Currently both are
represented as strings in the provider.

Ref: LOG-8179
Semver: patch