### PR TITLE
refactor: Bring presetalert resources calls to new style

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,10 @@ jobs:
       - run:
           name: "Run tests"
           command: |
-            mkdir -p /tmp/artifacts
-            TF_ACC=1 go test -v -coverprofile=/tmp/artifacts/profile.out -covermode=count ./logdna
-            go tool cover -html=/tmp/artifacts/profile.out -o /tmp/artifacts/coverage.html
-            goveralls -coverprofile=/tmp/artifacts/profile.out -service=circleci -repotoken $COVERALLS_REPO_TOKEN
+            make testcov
+            goveralls -coverprofile=coverage/coverage.out -service=circleci -repotoken $COVERALLS_REPO_TOKEN
       - store_artifacts:
-          path: /tmp/artifacts  
+          path: coverage
 workflows:
   update:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # In case of `make build`
 terraform-provider-logdna
 
-coverage.out
+coverage

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
-COVERAGEFILE?=coverage.out
+COVERAGEFILE?=coverage/coverage.out
 HOSTNAME=logdna.com
 NAMESPACE=logdna
 NAME=logdna
@@ -35,7 +35,8 @@ test:
 	TF_ACC=1 go test -v $(TESTARGS) ./logdna
 
 testcov:
+	mkdir -p coverage
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -coverprofile $(COVERAGEFILE)
-	go tool cover -html $(COVERAGEFILE)
+	go tool cover -html $(COVERAGEFILE) -o $(COVERAGEFILE).html
 
 .PHONY: build release install test testacc testcov

--- a/logdna/provider.go
+++ b/logdna/provider.go
@@ -9,7 +9,7 @@ import (
 
 type providerConfig struct {
 	serviceKey string
-	baseURL       string
+	baseURL    string
 	httpClient *http.Client
 }
 
@@ -41,7 +41,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	return &providerConfig{
 		serviceKey: servicekey,
-		baseURL:       url,
+		baseURL:    url,
 		httpClient: &http.Client{Timeout: 15 * time.Second},
 	}, nil
 }

--- a/logdna/provider_test.go
+++ b/logdna/provider_test.go
@@ -27,3 +27,11 @@ func TestProvider(t *testing.T) {
 func TestProvider_impl(t *testing.T) {
 	var _ *schema.Provider = Provider()
 }
+
+// testAccPreCheck validates the necessary test API keys exist
+// in the testing environment
+func testAccPreCheck(t *testing.T) {
+	if servicekey == "" {
+		t.Fatal("'servicekey' environment variable must be set for acceptance tests")
+	}
+}

--- a/logdna/request.go
+++ b/logdna/request.go
@@ -3,7 +3,6 @@ package logdna
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,14 +27,6 @@ type requestConfig struct {
 	httpRequest httpRequest
 	bodyReader  bodyReader
 	jsonMarshal jsonMarshal
-}
-
-// AlertResponsePayload contains the keys/vals used in alert API responses
-type AlertResponsePayload struct {
-	Channels []channelResponse `json:"channels,omitempty"`
-	Error    string            `json:"error,omitempty"`
-	Name     string            `json:"name,omitempty"`
-	PresetID string            `json:"presetid,omitempty"`
 }
 
 // newRequestConfig abstracts the struct creation to allow for mocking
@@ -76,64 +67,16 @@ func (c *requestConfig) MakeRequest() ([]byte, error) {
 	req.Header.Set("servicekey", c.serviceKey)
 	res, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error during HTTP request: %s, %+v", err, c)
+		return nil, fmt.Errorf("Error during HTTP request: %s", err)
 	}
 	defer res.Body.Close()
 
 	body, err := c.bodyReader(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing HTTP response: %s, %+v", err, c)
+		return nil, fmt.Errorf("Error parsing HTTP response: %s, %s", err, string(body))
 	}
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s %s, status %d NOT OK! %s", c.method, c.apiURL, res.StatusCode, string(body))
 	}
 	return body, err
-}
-
-// MakeRequestAlert makes a HTTP request to the config-api with alert payload data and parses and returns the response
-func MakeRequestAlert(c *requestConfig, url string, urlsuffix string, method string, payload viewRequest) (string, error) {
-	pbytes, err := json.Marshal(payload)
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequest(method, url+urlsuffix, bytes.NewBuffer(pbytes))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("servicekey", c.serviceKey)
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf(`Error with alert: %s`, err)
-	}
-	defer resp.Body.Close()
-	var result AlertResponsePayload
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
-		return "", err
-	}
-
-	if resp.StatusCode != 200 {
-		return "", errors.New(result.Error)
-	}
-
-	return result.PresetID, nil
-}
-
-// CreateAlert creates a Preset Alert with the provided payload
-func (c *requestConfig) CreateAlert(url string, payload viewRequest) (string, error) {
-	result, err := MakeRequestAlert(c, url, "/v1/config/presetalert", "POST", payload)
-	return result, err
-}
-
-// UpdateAlert updates a Preset Alert with the provided presetID and payload
-func (c *requestConfig) UpdateAlert(url string, presetID string, payload viewRequest) error {
-	_, err := MakeRequestAlert(c, url, "/v1/config/presetalert/"+presetID, "PUT", payload)
-	return err
-}
-
-// DeleteAlert deletes an alert with the provided presetID
-func (c *requestConfig) DeleteAlert(url, presetID string) error {
-	_, err := MakeRequestAlert(c, url, "/v1/config/presetalert/"+presetID, "DELETE", viewRequest{})
-	return err
 }

--- a/logdna/request_types.go
+++ b/logdna/request_types.go
@@ -131,9 +131,10 @@ func iterateIntegrationType(
 	var prepared interface{}
 	channelRequests := []channelRequest{}
 
-	if listEntries == nil {
-		return nil
+	if len(listEntries) == 0 {
+		return &channelRequests
 	}
+
 	for _, entry := range listEntries {
 		e := entry.(map[string]interface{})
 		prepared = nil

--- a/logdna/request_types_test.go
+++ b/logdna/request_types_test.go
@@ -1,0 +1,31 @@
+package logdna
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestTypes_iterateIntegrationType(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("Inserts a Diagnostics error for an unknown integration type", func(t *testing.T) {
+		var diags diag.Diagnostics
+		nonEmptyEntry := []interface{}{
+			map[string]interface{}{
+				"nah": "will not work",
+			},
+		}
+
+		channelRequests := iterateIntegrationType(nonEmptyEntry, "NOPE", &diags)
+
+		assert.Empty(*channelRequests, "Nothing was returned")
+		assert.Len(diags, 1, "There was 1 error")
+		assert.True(diags.HasError(), "The message is of type `Error`")
+
+		err := diags[0]
+		assert.Equal("Cannot format integration channel for outbound request", err.Summary, "Summary")
+		assert.Equal("Unrecognized integration: NOPE", err.Detail, "Detail")
+	})
+}

--- a/logdna/resource_view_test.go
+++ b/logdna/resource_view_test.go
@@ -15,7 +15,7 @@ func TestView_expectInvalidURLError(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testViewInvalidURL(),
-				ExpectError: regexp.MustCompile("Error: Error during HTTP request: Post \"http://api.logdna.co/v1/config/view\": dial tcp: lookup api.logdna.co: no such host"),
+				ExpectError: regexp.MustCompile("Error: Error during HTTP request: Post \"http://api.logdna.co/v1/config/view\": dial tcp: lookup api.logdna.co"),
 			},
 		},
 	})
@@ -292,8 +292,8 @@ func TestViewJSONUpdateError(t *testing.T) {
 	levels2 := "critical"
 	host1 := "host1"
 	host2 := "host2"
-	category1 := "DEMO"
-	category2 := "DEMO2"
+	category1 := "DEMOCATEGORY1"
+	category2 := "DemoCategory2"
 	tags1 := "host1"
 	tags2 := "host2"
 
@@ -306,10 +306,10 @@ func TestViewJSONUpdateError(t *testing.T) {
 					testViewExists("logdna_view.new"),
 				),
 			},
-			// {
-			// 	Config:      testViewConfigMultipleChannelsInvalidJSON(),
-			// 	ExpectError: regexp.MustCompile("bodytemplate json configuration is invalid"),
-			// },
+			{
+				Config:      testViewConfigMultipleChannelsInvalidJSON(),
+				ExpectError: regexp.MustCompile("Error: bodytemplate is not a valid JSON string"),
+			},
 		},
 	})
 }
@@ -323,8 +323,8 @@ func TestViewBulkEmails(t *testing.T) {
 	levels2 := "critical"
 	host1 := "host1"
 	host2 := "host2"
-	category1 := "DEMO"
-	category2 := "DEMO2"
+	category1 := "DEMOCATEGORY1"
+	category2 := "DemoCategory2"
 	tags1 := "host1"
 	tags2 := "host2"
 
@@ -341,7 +341,7 @@ func TestViewBulkEmails(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app1),
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app2),
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", category1),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
@@ -388,8 +388,8 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 	levels2 := "critical"
 	host1 := "host1"
 	host2 := "host2"
-	category := "DEMO"
-	category2 := "DEMO2"
+	category1 := "DEMOCATEGORY1"
+	category2 := "DemoCategory2"
 	tags1 := "host1"
 	tags2 := "host2"
 
@@ -408,7 +408,7 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testViewConfigBulkEmails(name, query, app1, app2, levels1, levels2, host1, host2, category, category2, tags1, tags2),
+				Config: testViewConfigBulkEmails(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2),
 				Check: resource.ComposeTestCheckFunc(
 					testViewExists("logdna_view.new"),
 					resource.TestCheckResourceAttr("logdna_view.new", "name", name),
@@ -417,7 +417,7 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app1),
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app2),
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", category),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
@@ -452,7 +452,7 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testViewConfigBulkEmails(name2, query2, app3, app4, levels3, levels4, host3, host4, category, category2, tags3, tags4),
+				Config: testViewConfigBulkEmails(name2, query2, app3, app4, levels3, levels4, host3, host4, category1, category2, tags3, tags4),
 				Check: resource.ComposeTestCheckFunc(
 					testViewExists("logdna_view.new"),
 					resource.TestCheckResourceAttr("logdna_view.new", "name", name2),
@@ -461,7 +461,7 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app3),
 					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app4),
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", category),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
 					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
@@ -508,8 +508,8 @@ func TestViewMultipleChannels(t *testing.T) {
 	levels2 := "critical"
 	host1 := "host1"
 	host2 := "host2"
-	category1 := "DEMO"
-	category2 := "DEMO2"
+	category1 := "DemoCategory1"
+	category2 := "DemoCategory2"
 	tags1 := "host1"
 	tags2 := "host2"
 
@@ -559,8 +559,8 @@ func TestViewMultipleChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", tags2),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.#", "1"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.%", "9"),
-					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.%", "9"),
-					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.bodytemplate", "{\"fields\":{\"description\":\"{{ matches }} matches found for {{ name }}\",\"issuetype\":{\"name\":\"Bug\"},\"project\":{\"key\":\"test\"},\"summary\":\"Alert From {{ name }}\"}}"),
+					// The JSON will have newlines per our API which uses JSON.stringify(obj, null, 2) as the value
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert From {{ name }}\"\n  }\n}"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.headers.%", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.headers.hello", "test3"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.headers.test", "test2"),

--- a/logdna/response_types_test.go
+++ b/logdna/response_types_test.go
@@ -1,0 +1,52 @@
+package logdna
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResponseTypes_mapAllChannelsToSchema(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("Inserts a Diagnostics error for an unknown integration type in the response", func(t *testing.T) {
+		channels := []channelResponse{
+			{Integration: "NOPE"},
+		}
+		channelIntegrations, diags := mapAllChannelsToSchema("view", &channels)
+
+		expected := map[string][]interface{}{
+			EMAIL:     make([]interface{}, 0),
+			PAGERDUTY: make([]interface{}, 0),
+			WEBHOOK:   make([]interface{}, 0),
+		}
+		assert.Equal(expected, channelIntegrations, "Nothing was returned")
+		assert.Len(*diags, 1, "There was 1 diags error")
+
+		err := (*diags)[0]
+		assert.Equal(diag.Warning, err.Severity, "The level is Warning")
+		assert.Equal("The remote view resource contains an unsupported integration: NOPE", err.Summary, "Summary")
+		assert.Equal("NOPE integration ignored since it does not map to the schema", err.Detail, "Detail")
+	})
+}
+
+func TestResponseTypes_appendError(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("appendError puts an error on the diags reference", func(t *testing.T) {
+		var diags diag.Diagnostics
+
+		err := errors.New("Some Error")
+
+		appendError(err, &diags)
+
+		assert.Len(diags, 1, "There was 1 diags error")
+
+		result := diags[0]
+		assert.Equal(diag.Error, result.Severity, "The level is Error")
+		assert.Equal("There was a problem setting the schema", result.Summary, "Summary")
+		assert.Equal("Some Error", result.Detail, "Detail")
+	})
+}


### PR DESCRIPTION
**fix: CI should use `make testcov` and use a coverage dir**

---

**refactor: Bring presetalert resources calls to new style**


---

**refactor: Abstractions to allow req/res parsing for multiple types**
