### PR TITLE
docs: Groom the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 terraform-provider-logdna
 
 coverage
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Terraform Provider for LogDNA
 
-[![CircleCI](https://circleci.com/gh/logdna/terraform-provider-logdna/tree/master.svg?style=svg)](https://app.circleci.com/pipelines/github/logdna/terraform-provider-logdna)
-[![Coverage Status](https://coveralls.io/repos/github/logdna/terraform-provider-logdna/badge.svg)](https://coveralls.io/github/logdna/terraform-provider-logdna)
+[![Coverage Status](https://coveralls.io/repos/github/logdna/terraform-provider-logdna/badge.svg?branch=main)](https://coveralls.io/github/logdna/terraform-provider-logdna?branch=main)
 [![Public Beta](https://img.shields.io/badge/-Public%20Beta-404346?style=flat)](#)
 
-[LogDNA](https://logdna.com) is a centralized log management platform. The LogDNA Provider allows organizations to manage Views and Alerts programmatically via Terraform.
+[LogDNA](https://logdna.com) is a centralized log management platform. The LogDNA Terraform Provider allows organizations to manage certain LogDNA resources (alerts, views, etc) programmatically via Terraform.
 
 The [official docs for the LogDNA terraform provider](https://registry.terraform.io/providers/logdna/logdna/latest/docs) can be found in the Terraform registry.
 
@@ -41,7 +40,7 @@ resource "logdna_alert" "my_alert" {
 }
 ```
 
-## Example Terraform Configuration for View-specific Alerts
+## Example Terraform Configuration for Views
 ```
 provider "logdna" {
   servicekey = "Your service key goes here"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,10 @@
 
 [![Public Beta](https://img.shields.io/badge/-Public%20Beta-404346?style=flat)](#)
 
-[LogDNA](https://logdna.com) is a centralized log management platform. The LogDNA Provider allows organizations to manage Views and Alerts programmatically via Terraform.
+[LogDNA](https://logdna.com) is a centralized log management platform. The LogDNA Terraform Provider allows organizations to manage certain LogDNA resources (alerts, views, etc) programmatically via Terraform.
 
-## Example Usage 
-```hcl 
+## Example Usage
+```hcl
 # Configure the LogDNA Provider
 provider "logdna" {
   servicekey = "xxxxxxxxxxxxxxxxxxxxxxxx"
@@ -16,11 +16,11 @@ resource "logdna_view" "http500" {
  name     = "HTTP 500s"
  query    = "response:500"
  email_channel {
-    emails          = ["test@logdna.com"]  # Email address to send alerts to
-    operator        = "presence"           # Trigger on the presence of lines
-    terminal        = "true"               # Alert at the end of the trigger interval
-    triggerinterval = "15m"                # Time window for alert (15 minutes)
-    triggerlimit    = 15                   # Lines threshold for alert (15 lines)
+    emails          = ["you@yourdomain.com"]  # Email address to send alerts to
+    operator        = "presence"              # Trigger on the presence of lines
+    terminal        = "true"                  # Alert at the end of the trigger interval
+    triggerinterval = "15m"                   # Time window for alert (15 minutes)
+    triggerlimit    = 15                      # Lines threshold for alert (15 lines)
  }
 }
 ```
@@ -28,15 +28,16 @@ resource "logdna_view" "http500" {
 ## Pre-requirements and considerations
 Before using Terraform for creating resources in LogDNA, review the following notes:
 - Verify Terraform is [installed](https://learn.hashicorp.com/tutorials/terraform/install-cli). The minimum supported version is 0.12.0 and can be checked by running `terraform version`.
+- The configurations seen in the examples will go into a Terraform configuration file such as `main.tf`.
 - Have the service key for your Organization available. To obtain the service key for your LogDNA Organization, go to the LogDNA dashboard and navigate to **Settings > Organization > API Keys** or follow this link [here](https://app.logdna.com/manage/api-keys).
-- Authentication is handled via the `servicekey` parameter and can be set in the provider configuration.
-- Be aware that the underlying LogDNA Configuration API has a rate limit of 50 requests per minute; therefore, when using the LogDNA Terraform provider, there is also a limit of 50 resource operations per minute.
-- If you do not provide a specific base URL in the provider configuration, the base url defaults to `https://api.logdna.com`.
-- If you want to create an Alert that uses PagerDuty to notify you, you will need to provide LogDNA with the [PagerDuty API key](https://support.pagerduty.com/docs/generating-api-keys#events-api-keys). To ensure that the LogDNA Dashboard properly displays the PagerDuty alert notification channel, we recommend that you first link the PagerDuty service to LogDNA via the [Dashboard UI](https://docs.logdna.com/docs/pagerduty-alert-integration), before using the Configuration API to create a PagerDuty Alert. However, not doing so doesn't in any way prevent the use of the Configuration API to create Alerts that use PagerDuty.
+- Authentication is handled via the `servicekey` parameter and can be set in the `provider` configuration section in the `.tf` file.
+- When using the LogDNA Terraform provider, be aware that there is a rate limit of 50 requests per minute.
+- If you do not provide a specific a `url` in the provider configuration, the URL defaults to `https://api.logdna.com` (recommended).
+- If you want to create an Alert that uses PagerDuty to notify you, you will need to provide LogDNA with the [PagerDuty API key](https://support.pagerduty.com/docs/generating-api-keys#events-api-keys). To ensure that the LogDNA Dashboard properly displays the PagerDuty alert notification channel, we recommend that you first link the PagerDuty service to LogDNA via the [Dashboard UI](https://docs.logdna.com/docs/pagerduty-alert-integration) before using this plugin to create a PagerDuty Alert. You may choose to create such resources first and then link PagerDuty, but be aware that they will not work as intended until the connection is reconciled.
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are supported by the `provider` section of the `.tf` file:
 
-- `servicekey`: _(Required)_ LogDNA Account Service Key. This can be generated or retrieved from Settings > Organization > API Keys. Type _string_
-- `url`: _(Optional)_ The LogDNA region URL. If you’re configuring an IBM Log Analysis with LogDNA or IBM Cloud Activity Tracker with LogDNA you’ll need to ensure `url` is set to the [right endpoint depending on the IBM region](https://cloud.ibm.com/docs/Log-Analysis-with-LogDNA?topic=Log-Analysis-with-LogDNA-endpoints#endpoints_api). Type _string_ (**_Default: api.logdna.com_**)
+- `servicekey`: **string _(Required)_** LogDNA Account Service Key. This can be generated or retrieved from Settings > Organization > API Keys.
+- `url`: **string** _(Optional; Default: api.logdna.com)_ The LogDNA region URL. If you’re configuring an IBM Log Analysis with LogDNA or IBM Cloud Activity Tracker with LogDNA, you’ll need to ensure `url` is set to the [correct endpoint depending on the IBM region](https://cloud.ibm.com/docs/Log-Analysis-with-LogDNA?topic=Log-Analysis-with-LogDNA-endpoints#endpoints_api).

--- a/docs/resources/logdna_alert.md
+++ b/docs/resources/logdna_alert.md
@@ -1,4 +1,4 @@
-# logdna_alert Resource
+# Resource: `logdna_alert`
 
 Manages [LogDNA Preset Alerts](https://docs.logdna.com/docs/alerts). Preset Alerts are alerts that you can define separately from a specific View. Preset Alerts can be created standalone and then attached (or detached) to any View, as opposed to View-specific Alerts, which are created specifically for a certain View.
 
@@ -75,7 +75,7 @@ resource "logdna_alert" "my_alert" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are supported by `logdna_alert`:
 
 - `name`: (Required) The name this Preset Alert will be given, type _string_
 
@@ -83,37 +83,37 @@ The following arguments are supported:
 
 `email_channel` supports the following arguments:
 
-- `emails`: _(Required)_ An array of email addresses (each email is of type _string_) to notify in the Alert
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
-- `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
-- `timezone`: _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), type _string_
-- `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
-- `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
+- `emails`: **_[]string (Required)_** An array of email addresses (strings) to notify in the Alert
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `timezone`: **_string_** _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 
 ### pagerduty_channel
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
-- `key`: _(Required)_ PagerDuty service key, type _string_
-- `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
-- `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
-- `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `key`: **_string (Required)_** The PagerDuty service key.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 
 ### webhook_channel
 
 `webhook_channel` supports the following arguments:
 
-- `bodytemplate`: _(Optional)_ JSON formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string. Type _string_
-- `headers`: _(Optional)_ Key-value pair for webhook request headers and header values, type Map of _strings_
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
-- `method`: _(Optional)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`. Type _string_ (**Default: "post"**)
-- `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
-- `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
-- `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
-- `url`: _(Required)_ URL of the webhook, type _string_
+- `bodytemplate`: **_string_** _(Optional)_ JSON-formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string.
+- `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request headers and header values. Example: `"MyHeader" = "MyValue"`
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `url`: **_string (Required)_** The URL of the webhook.
 
 

--- a/docs/resources/logdna_view.md
+++ b/docs/resources/logdna_view.md
@@ -1,6 +1,6 @@
-# logdna_view Resource
+# Resource: `logdna_view`
 
-Manages [LogDNA Views](https://docs.logdna.com/docs/views) as well as [View-specific Alerts](https://docs.logdna.com/docs/alerts#how-to-attach-an-alert-to-an-existing-view). To get started, specify a `name` and one of: `apps`, `hosts`, `levels`, `query` or `tags`. We currently support configuring Alerts to be sent via email, webhook, or PagerDuty.
+Manages [LogDNA Views](https://docs.logdna.com/docs/views) as well as [View-specific Alerts](https://docs.logdna.com/docs/alerts#how-to-attach-an-alert-to-an-existing-view). These differ from `logdna_alert` which are "preset alerts", while these are specific to certain views.  To get started, specify a `name` and one of: `apps`, `hosts`, `levels`, `query` or `tags`. We currently support configuring these view alerts to be sent via email, webhook, or PagerDuty.
 
 ## Example - Basic View
 
@@ -42,7 +42,7 @@ resource "logdna_view" "my_view" {
     triggerinterval = "15m"
     triggerlimit    = 15
   }
-  
+
   pagerduty_channel {
     key             = "Your PagerDuty API key goes here"
     terminal        = "true"
@@ -70,51 +70,51 @@ resource "logdna_view" "my_view" {
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are supported by `logdna_view`:
 
 _Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, `levels`, `query`, `tags` must be specified to create a View.
 
-- `apps`: _(Optional)_ Array of names of apps (each app is of type _string_) to filter the View by
-- `categories`: _(Optional)_ Array of existing category names (each category is of type _string_) this View should be nested under. _Note: If the category does not exist, the View will by default be created in uncategorized_
-- `hosts`: _(Optional)_ Array of names of hosts (each host is of type _string_) to filter the View by
-- `levels`: _(Optional)_ Array of names of levels (each level is of type _string_) to filter the View by
-- `name`: _(Required)_ Name this View will be given, type _string_
-- `query`: _(Optional)_  Search query scope for the View, type _string_
-- `tags`: _(Optional)_ Array of names of tags (each tag is of type _string_) to filter the View by
+- `apps`: **_string_** _(Optional)_ Array of app names to filter the View by.
+- `categories`: **[]string** _(Optional)_ Array of existing category names that this View should be nested under. _Note: If the category does not exist, the View will by default be created in uncategorized_.
+- `hosts`: **[]string** _(Optional)_ Array of host names to filter the View by.
+- `levels`: **[]string** _(Optional)_ Array of level names to filter the View by.
+- `name`: **string _(Required)_** The name of this View.
+- `query`: **string** _(Optional)_  Search query for the View.
+- `tags`: **[]string** _(Optional)_ Array of tag names to filter the View by.
 
 ### email_channel
 
 `email_channel` supports the following arguments:
 
-- `emails`: _(Required)_ An array of email addresses (each email is of type _string_) to notify in the Alert
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
-- `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
-- `timezone`: _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), type _string_
-- `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
-- `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
+- `emails`: **[]string _(Required)_** An array of email addresses (strings) to notify in the Alert
+- `immediate`: **string** _(Optional; Default: `"false"`)_ Whether the Alert will be triggered immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `operator`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
+- `timezone`: **string** _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 
 ### pagerduty_channel
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
-- `key`: _(Required)_ PagerDuty service key, type _string_
-- `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
-- `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
-- `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will be triggered immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts, and `"false"` for absence Alerts.
+- `key`: **string _(Required)_** The service key used for PagerDuty.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 
 ### webhook_channel
 
 `webhook_channel` supports the following arguments:
 
-- `bodytemplate`: _(Optional)_ JSON formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string. Type _string_
-- `headers`: _(Optional)_ Key-value pair for webhook request headers and header values, type Map of _strings_
-- `immediate`: _(Optional)_ Whether the Alert will trigger immediately after the trigger limit is reached. _Note: Immediate can only be set to `true` for presence alerts_. Valid options are `true` and `false` for presence Alerts and `false` for absence Alerts, type _string_ (**Default: "false"**)
-- `method`: _(Optional)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`. Type _string_ (**Default: "post"**)
-- `operator`: _(Optional)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`, type _string_ (**Default: "presence"**)
-- `terminal`: _(Optional)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `true` and `false` for presence Alerts and `true` for absence Alerts, type _string_ (**Default: "true"**)
-- `triggerinterval`: _(Optional)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. Type _string_ (**Defaults: "30" for presence; "15m" for absence**)
-- `triggerlimit`: _(Required)_ Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`), type _integer_
-- `url`: _(Required)_ URL of the webhook, type _string_
+- `bodytemplate`: **string** _(Optional)_ JSON-formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string.
+- `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request headers and header values. Example: `"MyHeader" = "MyValue"`
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts, and `"false"` for absence Alerts.
+- `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`)
+- `url`: **_string (Required)_** The URL of the webhook.

--- a/examples/many_views.tf
+++ b/examples/many_views.tf
@@ -2,103 +2,50 @@ provider "logdna" {
   servicekey = "Your service key goes here"
 }
 
-resource "logdna_view" "my_view" {
-  name  = "test1"
-  query = "test"
+resource "logdna_view" "kube_probes" {
+  name  = "kube_probes"
+  query = "agent:kube-probe"
+  pagerduty_channel {
+    immediate         = "true"
+    triggerinterval   = "30m"
+    triggerlimit      = 30
+    key               = "Your PagerDuty API key goes here"
+  }
 }
 
-resource "logdna_view" "my_view2" {
-  name  = "test2"
-  query = "test"
+resource "logdna_view" "e2e_metrics_reporter" {
+  name  = "e2e_metrics_reporter"
+  query = "app:e2e-latency-metrics-reporter"
+  apps  = ["reporting", "metrics"]
 }
 
-resource "logdna_view" "my_view3" {
-  name  = "test3"
-  query = "test"
+resource "logdna_view" "not_info_logs" {
+  name  = "not_info_logs"
+  query = "-level:info"
+  webhook_channel {
+    bodytemplate = jsonencode({
+      fields = {
+        description = "{{ matches }} matches found for {{ name }}"
+        headers = {
+          x-reported-from = "terraform"
+        }
+        project = {
+          key = "not_info_logs"
+        },
+        summary = "Non-info log entries from {{ name }}"
+      }
+    })
+    immediate       = "false"
+    terminal        = "true"
+    method          = "post"
+    url             = "https://ourwebhook/log_responses/not_info"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+  }
 }
 
-resource "logdna_view" "my_view4" {
-  name  = "test4"
-  query = "test"
+resource "logdna_view" "exception_errors" {
+  name    = "exception_errors"
+  query   = "ClassCastException OR NullPointerException"
+  levels  = ["fatal", "critical"]
 }
-
-resource "logdna_view" "my_view5" {
-  name  = "test5"
-  query = "test"
-}
-
-resource "logdna_view" "my_view6" {
-  name  = "test6"
-  query = "test"
-}
-
-resource "logdna_view" "my_view7" {
-  name  = "test7"
-  query = "test"
-}
-
-resource "logdna_view" "my_view8" {
-  name  = "test8"
-  query = "test"
-}
-
-resource "logdna_view" "my_view9" {
-  name  = "test9"
-  query = "test"
-}
-
-resource "logdna_view" "my_view10" {
-  name  = "test10"
-  query = "test"
-}
-
-resource "logdna_view" "my_view11" {
-  name  = "test11"
-  query = "test"
-}
-
-resource "logdna_view" "my_view12" {
-  name  = "test12"
-  query = "test"
-}
-
-resource "logdna_view" "my_view13" {
-  name  = "test13"
-  query = "test"
-}
-
-resource "logdna_view" "my_view14" {
-  name  = "test14"
-  query = "test"
-}
-
-resource "logdna_view" "my_view15" {
-  name  = "test15"
-  query = "test"
-}
-
-resource "logdna_view" "my_view16" {
-  name  = "test16"
-  query = "test"
-}
-
-resource "logdna_view" "my_view17" {
-  name  = "test17"
-  query = "test"
-}
-
-resource "logdna_view" "my_view18" {
-  name  = "test18"
-  query = "test"
-}
-
-resource "logdna_view" "my_view19" {
-  name  = "test19"
-  query = "test"
-}
-
-resource "logdna_view" "my_view20" {
-  name  = "test20"
-  query = "test"
-}
-


### PR DESCRIPTION
Some of the technical docs needed to be cleaned up in terms of
how we show parameter types and default values. Various other
small corrections, too.