### PR TITLE
feat: enable `terraform import` for alerts/views

### DIFF
--- a/docs/resources/logdna_alert.md
+++ b/docs/resources/logdna_alert.md
@@ -73,6 +73,17 @@ resource "logdna_alert" "my_alert" {
 }
 ```
 
+## Import
+
+Preset Alerts can be imported by `id`, which can be found in the URL when editing the
+Preset Alert in the web UI:
+
+```sh
+$ terraform import logdna_alert.your-alert-name <id>
+```
+
+Note that only the alert channels supported by this provider will be imported.
+
 ## Argument Reference
 
 The following arguments are supported by `logdna_alert`:

--- a/docs/resources/logdna_view.md
+++ b/docs/resources/logdna_view.md
@@ -68,6 +68,17 @@ resource "logdna_view" "my_view" {
 }
 ```
 
+## Import
+
+Views can be imported by `id`, which can be found in the URL when editing the
+View in the web UI:
+
+```sh
+$ terraform import logdna_view.your-view-name <id>
+```
+
+Note that only the alert channels supported by this provider will be imported.
+
 ## Argument Reference
 
 The following arguments are supported by `logdna_view`:

--- a/logdna/resource_alert.go
+++ b/logdna/resource_alert.go
@@ -157,6 +157,9 @@ func resourceAlert() *schema.Resource {
 		ReadContext:   resourceAlertRead,
 		UpdateContext: resourceAlertUpdate,
 		DeleteContext: resourceAlertDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/logdna/resource_alert_test.go
+++ b/logdna/resource_alert_test.go
@@ -196,6 +196,11 @@ func TestAlertBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
 				),
 			},
+			{
+				ResourceName:      "logdna_alert.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -245,6 +250,11 @@ func TestAlertBasicUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
 				),
 			},
+			{
+				ResourceName:      "logdna_alert.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -260,6 +270,11 @@ func TestAlertJSONUpdateError(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAlertExists("logdna_alert.new"),
 				),
+			},
+			{
+				ResourceName:      "logdna_alert.new",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config:      testAlertConfigMultipleChannelsInvalidJSON(),
@@ -298,6 +313,11 @@ func TestAlertMultipleChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.triggerlimit", "15"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert From {{ name }}\"\n  }\n}"),
 				),
+			},
+			{
+				ResourceName:      "logdna_alert.new",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config:      testAlertConfigMultipleChannelsInvalidJSON(),

--- a/logdna/resource_view.go
+++ b/logdna/resource_view.go
@@ -171,6 +171,9 @@ func resourceView() *schema.Resource {
 		ReadContext:   resourceViewRead,
 		UpdateContext: resourceViewUpdate,
 		DeleteContext: resourceViewDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"apps": {

--- a/logdna/resource_view_test.go
+++ b/logdna/resource_view_test.go
@@ -250,6 +250,11 @@ func TestViewBasic(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "query", query),
 				),
 			},
+			{
+				ResourceName:      "logdna_view.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -279,6 +284,11 @@ func TestViewBasicUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "query", query2),
 				),
 			},
+			{
+				ResourceName:      "logdna_view.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -305,6 +315,11 @@ func TestViewJSONUpdateError(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testViewExists("logdna_view.new"),
 				),
+			},
+			{
+				ResourceName:      "logdna_view.new",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config:      testViewConfigMultipleChannelsInvalidJSON(),
@@ -374,6 +389,11 @@ func TestViewBulkEmails(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", tags2),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channels.#", "0"),
 				),
+			},
+			{
+				ResourceName:      "logdna_view.new",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -495,6 +515,11 @@ func TestViewBulkEmailsUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channels.#", "0"),
 				),
 			},
+			{
+				ResourceName:      "logdna_view.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -572,6 +597,11 @@ func TestViewMultipleChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.triggerlimit", "15"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.url", "https://yourwebhook/endpoint"),
 				),
+			},
+			{
+				ResourceName:      "logdna_view.new",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
This adds the necessary configuration to view and alert resources
to support `terraform import`. There is nothing extra needed here,
this allows all of the "native" import behavior to work as it should.

Ref: LOG-10221
