### PR TITLE
feat(stream): add stream_config and stream_exclusion resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
           triggeredBy 'issueCommentCause'
         }
       }
+
       steps {
         error('A maintainer needs to approve this PR for CI by commenting')
       }
@@ -34,6 +35,10 @@ pipeline {
           label 'ec2-fleet'
           customWorkspace "${PROJECT_NAME}-${BUILD_NUMBER}"
         }
+      }
+
+      environment {
+        GIT_BRANCH = "${CURRENT_BRANCH}"
       }
 
       steps {

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ lint:
 	$(LINT_CMD)
 
 test-local: .env-SERVICE_KEY lint
-	TF_ACC=1 go test -v $(TEST_ARGS) ./logdna
+	TF_ACC=1 go test -v $(TEST_ARGS) ./logdna -coverprofile $(COVERAGE_FILE)
+	go tool cover -html $(COVERAGE_FILE) -o $(COVERAGE_FILE).html
 
 test: BUILD_FLAGS:=--env SERVICE_KEY --env TF_ACC=1
 test: .env-SERVICE_KEY build-image lint
@@ -58,7 +59,7 @@ testcov: .env-SERVICE_KEY build-image lint
 	$(BUILD_ENV) go test $(TEST) -v $(TEST_ARGS) -coverprofile $(COVERAGE_FILE)
 	$(BUILD_ENV) go tool cover -html $(COVERAGE_FILE) -o $(COVERAGE_FILE).html
 
-postcov: BUILD_FLAGS:=--env COVERALLS_TOKEN 
+postcov: BUILD_FLAGS:=--env COVERALLS_TOKEN --env GIT_BRANCH
 postcov: testcov .env-COVERALLS_TOKEN
 	$(BUILD_ENV) goveralls -coverprofile=${COVERAGE_FILE} -service jenkins
 

--- a/docs/resources/logdna_stream_config.md
+++ b/docs/resources/logdna_stream_config.md
@@ -1,0 +1,47 @@
+# Resource: `logdna_stream_config`
+
+> **IBM Log Analysis and Cloud Activity Tracker users only**
+
+Manages [LogDNA Streaming](https://ibm.github.io/cloud-enterprise-examples/log-streaming/content-overview/) configuration for an account.
+
+## Example
+
+```hcl
+provider "logdna" {
+  servicekey = "xxxxxxxxxxxxxxxxxxxxxxxx"
+  url = "https://api.logdna.com" # (Optional) specify a LogDNA region
+}
+
+resource "logdna_stream_config" "config" {
+  user      = var.stream_user
+  password  = var.stream_password
+  topic     = "example"
+  brokers   = [
+    "broker-1.example.org:9093",
+    "broker-2.example.org:9093",
+    "broker-3.example.org:9093",
+  ]
+}
+```
+
+## Import
+
+Importing an existing configuration is supported:
+
+```sh
+$ terraform import logdna_stream_config.config stream
+```
+
+## Argument Reference
+
+The following arguments are supported by `logdna_stream_config`:
+
+- `brokers`: **[]string** _(Required)_ List of of broker URLs. 
+- `topic`: **string** _(Required)_ The topic that logs will be published on.
+- `user`: **string** _(Required)_ The SASL username for the connection.
+- `password`: **string** _(Required)_ The SASL password for the connection.
+
+Note that the provided brokers and credentials must be valid, and
+the brokers must be reachable when the resource is created or updated.
+The connection to the broker will be validated before the configuration
+can be saved.

--- a/docs/resources/logdna_stream_exclusion.md
+++ b/docs/resources/logdna_stream_exclusion.md
@@ -1,0 +1,51 @@
+# Resource: `logdna_stream_exclusion`
+
+> **IBM Log Analysis and Cloud Activity Tracker users only**
+
+Manages exclusion rules for [LogDNA Streaming](https://ibm.github.io/cloud-enterprise-examples/log-streaming/content-overview/).
+Stream exclusion rules define the applications, hostnames, and patterns within
+log lines that should exclude a given line from the stream.
+
+## Example
+
+```hcl
+provider "logdna" {
+  servicekey = "xxxxxxxxxxxxxxxxxxxxxxxx"
+  url = "https://api.logdna.com" # (Optional) specify a LogDNA region
+}
+
+resource "logdna_stream_exclusion" "http-success" {
+  title  = "HTTP 2XX"
+  apps   = ["nginx", "apache"]
+  query  = "response:(>=200 <300) request:*"
+  active = true
+}
+
+resource "logdna_stream_exclusion" "http-noise" {
+  title  = "Noisy HTTP Paths"
+  apps   = ["nginx", "apache"]
+  query  = "robots.txt OR favicon.ico OR .well-known"
+  active = true
+}
+```
+
+## Import
+
+Stream Exclusions can be imported by `id`, which can be found
+in the URL when editing the Stream Exclusion in the web UI:
+
+```sh
+$ terraform import logdna_stream_exclusion.your-rule-name <id>
+```
+
+## Argument Reference
+
+The following arguments are supported by `logdna_stream_exclusion`:
+
+_Note:_ A `title` and at least one of the following properties: `apps`, `hosts`, `query` must be specified to create this resource.
+
+- `title`: **string** _(Required)_ Title of this exclusion rule that will appear in the UI.
+- `active`: **_bool_** _(Optional; Default: false)_ Whether the rule should be active.
+- `apps`: **_[]string_** _(Optional)_ Array of app names to exclude.
+- `hosts`: **_[]string_** _(Optional)_ Array of hosts to exclude.
+- `query`: **_string_** _(Optional)_ A search query to match lines to exclude

--- a/examples/stream_config.tf
+++ b/examples/stream_config.tf
@@ -1,0 +1,14 @@
+provider "logdna" {
+  servicekey = "Your service key goes here"
+}
+
+resource "logdna_stream_config" "config" {
+  user      = var.stream_user
+  password  = var.stream_password
+  topic     = "example"
+  brokers = [
+    "broker-1.example.org:9093",
+    "broker-2.example.org:9093",
+    "broker-3.example.org:9093",
+  ]
+}

--- a/examples/stream_exclusions.tf
+++ b/examples/stream_exclusions.tf
@@ -1,0 +1,17 @@
+provider "logdna" {
+  servicekey = "Your service key goes here"
+}
+
+resource "logdna_stream_exclusion" "http-success" {
+  title  = "HTTP 2XX"
+  apps   = ["nginx", "apache"]
+  query  = "response:(>=200 <300) request:*"
+  active = true
+}
+
+resource "logdna_stream_exclusion" "http-noise" {
+  title  = "Noisy HTTP Paths"
+  apps   = ["nginx", "apache"]
+  query  = "robots.txt OR favicon.ico OR .well-known"
+  active = true
+}

--- a/logdna/provider.go
+++ b/logdna/provider.go
@@ -28,9 +28,10 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"logdna_alert":         resourceAlert(),
-			"logdna_view":          resourceView(),
-			"logdna_stream_config": resourceStreamConfig(),
+			"logdna_alert":            resourceAlert(),
+			"logdna_view":             resourceView(),
+			"logdna_stream_config":    resourceStreamConfig(),
+			"logdna_stream_exclusion": resourceStreamExclusion(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/logdna/provider.go
+++ b/logdna/provider.go
@@ -28,8 +28,9 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"logdna_alert": resourceAlert(),
-			"logdna_view":  resourceView(),
+			"logdna_alert":         resourceAlert(),
+			"logdna_view":          resourceView(),
+			"logdna_stream_config": resourceStreamConfig(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/logdna/request.go
+++ b/logdna/request.go
@@ -42,7 +42,7 @@ func newRequestConfig(pc *providerConfig, method string, uri string, body interf
 		jsonMarshal: json.Marshal,
 	}
 
-	// Used during esting only; Allow mutations passed in by tests
+	// Used during testing only; Allow mutations passed in by tests
 	for _, mutator := range mutators {
 		mutator(rc)
 	}

--- a/logdna/request_types.go
+++ b/logdna/request_types.go
@@ -53,21 +53,11 @@ func (view *viewRequest) CreateRequestBody(d *schema.ResourceData) diag.Diagnost
 	view.Query = d.Get("query").(string)
 
 	// Simple arrays
-	for _, app := range d.Get("apps").([]interface{}) {
-		view.Apps = append(view.Apps, app.(string))
-	}
-	for _, category := range d.Get("categories").([]interface{}) {
-		view.Category = append(view.Category, category.(string))
-	}
-	for _, host := range d.Get("hosts").([]interface{}) {
-		view.Hosts = append(view.Hosts, host.(string))
-	}
-	for _, level := range d.Get("levels").([]interface{}) {
-		view.Levels = append(view.Levels, level.(string))
-	}
-	for _, tag := range d.Get("tags").([]interface{}) {
-		view.Tags = append(view.Tags, tag.(string))
-	}
+	view.Apps = listToStrings(d.Get("apps").([]interface{}))
+	view.Category = listToStrings(d.Get("categories").([]interface{}))
+	view.Hosts = listToStrings(d.Get("hosts").([]interface{}))
+	view.Levels = listToStrings(d.Get("levels").([]interface{}))
+	view.Tags = listToStrings(d.Get("tags").([]interface{}))
 
 	// Complex array interfaces
 	view.Channels = *aggregateAllChannelsFromSchema(d, &diags)
@@ -230,4 +220,16 @@ func webHookChannelRequest(s map[string]interface{}, diags *diag.Diagnostics) ch
 	}
 
 	return c
+}
+
+func listToStrings(list []interface{}) []string {
+	strs := make([]string, 0, len(list))
+	for _, elem := range list {
+		val, ok := elem.(string)
+		if ok && val != "" {
+			strs = append(strs, val)
+		}
+	}
+
+	return strs
 }

--- a/logdna/resource_stream_config.go
+++ b/logdna/resource_stream_config.go
@@ -1,0 +1,178 @@
+package logdna
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const streamConfigID = "stream"
+
+type streamConfig struct {
+	Status   string   `json:"status,omitempty"`
+	Brokers  []string `json:"brokers"`
+	Topic    string   `json:"topic"`
+	User     string   `json:"user"`
+	Password string   `json:"password"`
+}
+
+func resourceStreamConfigCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	pc := m.(*providerConfig)
+	c := streamConfig{
+		Brokers:  listToStrings(d.Get("brokers").([]interface{})),
+		Topic:    d.Get("topic").(string),
+		User:     d.Get("user").(string),
+		Password: d.Get("password").(string),
+	}
+
+	req := newRequestConfig(
+		pc,
+		"POST",
+		"/v1/config/stream",
+		c,
+	)
+
+	body, err := req.MakeRequest()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	cn := streamConfig{}
+	err = json.Unmarshal(body, &cn)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(streamConfigID)
+	appendError(d.Set("brokers", cn.Brokers), &diags)
+	appendError(d.Set("topic", cn.Topic), &diags)
+	appendError(d.Set("user", cn.User), &diags)
+	appendError(d.Set("status", cn.Status), &diags)
+
+	return diags
+}
+
+func resourceStreamConfigRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	pc := m.(*providerConfig)
+	req := newRequestConfig(
+		pc,
+		"GET",
+		"/v1/config/stream",
+		nil,
+	)
+
+	body, err := req.MakeRequest()
+
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot read the remote stream config resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	c := streamConfig{}
+	err = json.Unmarshal(body, &c)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot unmarshal response from the remote stream config resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	appendError(d.Set("brokers", c.Brokers), &diags)
+	appendError(d.Set("topic", c.Topic), &diags)
+	appendError(d.Set("user", c.User), &diags)
+	appendError(d.Set("status", c.Status), &diags)
+
+	return diags
+}
+
+func resourceStreamConfigUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	c := streamConfig{
+		Brokers:  listToStrings(d.Get("brokers").([]interface{})),
+		Topic:    d.Get("topic").(string),
+		User:     d.Get("user").(string),
+		Password: d.Get("password").(string),
+	}
+
+	req := newRequestConfig(
+		pc,
+		"PUT",
+		"/v1/config/stream",
+		c,
+	)
+
+	_, err := req.MakeRequest()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceStreamConfigRead(ctx, d, m)
+}
+
+func resourceStreamConfigDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	req := newRequestConfig(
+		pc,
+		"DELETE",
+		"/v1/config/stream",
+		nil,
+	)
+
+	_, err := req.MakeRequest()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceStreamConfig() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStreamConfigCreate,
+		ReadContext:   resourceStreamConfigRead,
+		UpdateContext: resourceStreamConfigUpdate,
+		DeleteContext: resourceStreamConfigDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"brokers": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
+				Required: true,
+			},
+			"topic": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"user": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}

--- a/logdna/resource_stream_config_test.go
+++ b/logdna/resource_stream_config_test.go
@@ -1,0 +1,183 @@
+package logdna
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamConfig_expectInvalidURLError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamConfig(`
+					brokers = ["https://broker-1.example.org:9090"]
+					topic = "test-topic"
+					user = "test-user"
+					password = "test-password"
+				`, "http://api.logdna.co"),
+				ExpectError: regexp.MustCompile("Error: error during HTTP request: Post \"http://api.logdna.co/v1/config/stream\": dial tcp: lookup api.logdna.co"),
+			},
+		},
+	})
+}
+
+func TestStreamConfig_expectInvalidBrokerError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamConfig(`
+					brokers = ["https://broker-1.example.org:9090"]
+					topic = "test-topic"
+					user = "test-user"
+					password = "test-password"
+				`, ""),
+				ExpectError: regexp.MustCompile(`Unable to validate connection to the Kafka broker`),
+			},
+		},
+	})
+}
+
+func TestStreamConfig_expectInvalidConfigError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamConfig(`
+					brokers = ["https://broker-1.example.org:9090"]
+					topic = ""
+					user = ""
+					password = ""
+				`, ""),
+				ExpectError: regexp.MustCompile(`\\"topic\\" is not allowed to be empty.*\\"user\\" is not allowed to be empty.*\\"password\\" is not allowed to be empty`),
+			},
+		},
+	})
+}
+
+func TestStreamConfig_basic(t *testing.T) {
+	assert := assert.New(t)
+	brokers := []string{
+		"https://broker-1.example.org:9090",
+		"https://broker-2.example.org:9090",
+	}
+	topic := "test-topic"
+	user := "test-user"
+	password := "test-password"
+
+	// This resource requires a valid Kafka broker, so this test runs against a mock server/
+	// This TestCase is doing a Create and Update, both of which perform a Read at the
+	// end of the routine and a refresh between steps. The test server response is
+	// tailored to the request by the request number to return what is expected from the
+	// step's config. This is a hacky workaround but avoids the need for real Kafka
+	// infrastructure for the validation that occurs in this endpoint.
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count++
+		t := topic
+		if count > 4 {
+			t = "updated"
+		}
+		err := json.NewEncoder(w).Encode(streamConfig{
+			Brokers: brokers,
+			Topic:   t,
+			User:    user,
+			Status:  "active",
+		})
+		assert.Nil(err, "No errors")
+	}))
+	defer ts.Close()
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamConfig(fmt.Sprintf(`
+					brokers = [
+						"%s",
+						"%s"
+					]
+					topic = "%s"
+					user = "%s"
+					password = "%s"
+				`, brokers[0], brokers[1], topic, user, password,
+				), ts.URL),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamConfigExists("logdna_stream_config.stream"),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "topic", topic),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "user", user),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "status", "active"),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "brokers.#", "2"),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "brokers.0", brokers[0]),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "brokers.1", brokers[1]),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "password", password),
+				),
+			},
+			{
+				Config: testStreamConfig(fmt.Sprintf(`
+					brokers = [
+						"%s",
+						"%s"
+					]
+					topic = "updated"
+					user = "%s"
+					password = "%s"
+				`, brokers[0], brokers[1], user, password,
+				), ts.URL),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamConfigExists("logdna_stream_config.stream"),
+					resource.TestCheckResourceAttr("logdna_stream_config.stream", "topic", "updated"),
+				),
+			},
+			{
+				ResourceName:      "logdna_stream_config.stream",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func testStreamConfigExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID set")
+		}
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		return nil
+	}
+}
+
+func testStreamConfig(fields string, url string) string {
+	uc := ""
+	if url != "" {
+		uc = fmt.Sprintf(`url = "%s"`, url)
+	}
+
+	return fmt.Sprintf(`
+		provider "logdna" {
+			servicekey = "%s"
+			%s
+		}
+		
+		resource "logdna_stream_config" "stream" {
+			%s
+		}
+	`, serviceKey, uc, fields)
+}

--- a/logdna/resource_stream_exclusion.go
+++ b/logdna/resource_stream_exclusion.go
@@ -1,0 +1,192 @@
+package logdna
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type streamExclusion struct {
+	ID     string   `json:"id,omitempty"`
+	Title  string   `json:"title"`
+	Active bool     `json:"active"`
+	Apps   []string `json:"apps"`
+	Hosts  []string `json:"hosts"`
+	Query  string   `json:"query"`
+}
+
+var streamExclusionAtLeastOneOfFields = []string{"apps", "hosts", "query"}
+
+func resourceStreamExclusionCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	pc := m.(*providerConfig)
+	ex := streamExclusion{
+		Title:  d.Get("title").(string),
+		Active: d.Get("active").(bool),
+		Apps:   listToStrings(d.Get("apps").([]interface{})),
+		Hosts:  listToStrings(d.Get("hosts").([]interface{})),
+		Query:  d.Get("query").(string),
+	}
+
+	req := newRequestConfig(
+		pc,
+		"POST",
+		"/v1/config/stream/exclusions",
+		ex,
+	)
+
+	body, err := req.MakeRequest()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	exn := streamExclusion{}
+	err = json.Unmarshal(body, &exn)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(exn.ID)
+	appendError(d.Set("title", exn.Title), &diags)
+	appendError(d.Set("active", exn.Active), &diags)
+	appendError(d.Set("apps", exn.Apps), &diags)
+	appendError(d.Set("hosts", exn.Hosts), &diags)
+	appendError(d.Set("query", exn.Query), &diags)
+
+	return diags
+}
+
+func resourceStreamExclusionRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	pc := m.(*providerConfig)
+	req := newRequestConfig(
+		pc,
+		"GET",
+		fmt.Sprintf("/v1/config/stream/exclusions/%s", d.Id()),
+		nil,
+	)
+
+	body, err := req.MakeRequest()
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot read the remote stream exclusion resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	ex := streamExclusion{}
+	err = json.Unmarshal(body, &ex)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot unmarshal response from the remote stream exclusion resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	appendError(d.Set("title", ex.Title), &diags)
+	appendError(d.Set("active", ex.Active), &diags)
+	appendError(d.Set("apps", ex.Apps), &diags)
+	appendError(d.Set("hosts", ex.Hosts), &diags)
+	appendError(d.Set("query", ex.Query), &diags)
+
+	return diags
+}
+
+func resourceStreamExclusionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	ex := streamExclusion{
+		Title:  d.Get("title").(string),
+		Active: d.Get("active").(bool),
+		Apps:   listToStrings(d.Get("apps").([]interface{})),
+		Hosts:  listToStrings(d.Get("hosts").([]interface{})),
+		Query:  d.Get("query").(string),
+	}
+
+	req := newRequestConfig(
+		pc,
+		"PATCH",
+		fmt.Sprintf("/v1/config/stream/exclusions/%s", d.Id()),
+		ex,
+	)
+
+	_, err := req.MakeRequest()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceStreamExclusionRead(ctx, d, m)
+}
+
+func resourceStreamExclusionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	pc := m.(*providerConfig)
+	req := newRequestConfig(
+		pc,
+		"DELETE",
+		fmt.Sprintf("/v1/config/stream/exclusions/%s", d.Id()),
+		nil,
+	)
+
+	_, err := req.MakeRequest()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceStreamExclusion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceStreamExclusionCreate,
+		ReadContext:   resourceStreamExclusionRead,
+		UpdateContext: resourceStreamExclusionUpdate,
+		DeleteContext: resourceStreamExclusionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"title": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"active": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+			"apps": {
+				Type:         schema.TypeList,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				MinItems:     1,
+				Optional:     true,
+				AtLeastOneOf: streamExclusionAtLeastOneOfFields,
+			},
+			"hosts": {
+				Type:         schema.TypeList,
+				Elem:         &schema.Schema{Type: schema.TypeString},
+				MinItems:     1,
+				Optional:     true,
+				AtLeastOneOf: streamExclusionAtLeastOneOfFields,
+			},
+			"query": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				AtLeastOneOf: streamExclusionAtLeastOneOfFields,
+			},
+		},
+	}
+}

--- a/logdna/resource_stream_exclusion_test.go
+++ b/logdna/resource_stream_exclusion_test.go
@@ -1,0 +1,162 @@
+package logdna
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestStreamExclusion_expectInvalidURLError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamExclusion(`
+					title = "test-title"
+					query = "query-foo AND query-bar"			
+				`, "http://api.logdna.co"),
+				ExpectError: regexp.MustCompile("Error: error during HTTP request: Post \"http://api.logdna.co/v1/config/stream/exclusions\": dial tcp: lookup api.logdna.co"),
+			},
+		},
+	})
+}
+
+func TestStreamExclusion_expectInvalidError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamExclusion(`
+					title = "test-title"
+				`, ""),
+				ExpectError: regexp.MustCompile("one of `apps,hosts,query` must be specified"),
+			},
+			{
+				Config: testStreamExclusion(`
+					title = ""
+					query = "test-query"
+				`, ""),
+				ExpectError: regexp.MustCompile(`\\"title\\" is not allowed to be empty`),
+			},
+			{
+				Config: testStreamExclusion(`
+					title = "test-title"
+					apps = []
+				`, ""),
+				ExpectError: regexp.MustCompile("requires 1 item minimum, but config has only 0 declared"),
+			},
+		},
+	})
+}
+
+func TestStreamExclusion_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testStreamExclusion(`
+					title = "test-title"
+					active = true
+					apps = [
+						"app-1",
+						"app-2"
+					]
+					hosts = [
+						"host-1",
+						"host-2"
+					]
+					query = "query-foo AND query-bar"
+				`, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamExclusionExists("logdna_stream_exclusion.new"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "title", "test-title"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "active", "true"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "apps.#", "2"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "apps.0", "app-1"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "apps.1", "app-2"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "hosts.#", "2"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "hosts.0", "host-1"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "hosts.1", "host-2"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "query", "query-foo AND query-bar"),
+				),
+			},
+			{
+				Config: testStreamExclusion(`
+					title = "test-title-update"
+					active = false
+					apps = [
+						"app-1",
+						"app-2"
+					]
+					hosts = [
+						"host-1",
+						"host-2"
+					]
+					query = "query-foo AND query-bar"
+				`, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamExclusionExists("logdna_stream_exclusion.new"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "title", "test-title-update"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "active", "false"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "apps.#", "2"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "hosts.#", "2"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "query", "query-foo AND query-bar"),
+				),
+			},
+			{
+				Config: testStreamExclusion(`
+					title = "test-title-update"
+					active = false
+					apps = [
+						"app-1",
+						"app-2"
+					]
+					query = "query-foo AND query-bar"
+				`, ""),
+				Check: resource.ComposeTestCheckFunc(
+					testStreamExclusionExists("logdna_stream_exclusion.new"),
+					resource.TestCheckResourceAttr("logdna_stream_exclusion.new", "hosts.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "logdna_stream_exclusion.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testStreamExclusionExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID set")
+		}
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		return nil
+	}
+}
+
+func testStreamExclusion(fields string, url string) string {
+	uc := ""
+	if url != "" {
+		uc = fmt.Sprintf(`url = "%s"`, url)
+	}
+
+	return fmt.Sprintf(`
+		provider "logdna" {
+			servicekey = "%s"
+			%s
+		}
+		resource "logdna_stream_exclusion" "new" {
+			%s
+		}
+	`, serviceKey, uc, fields)
+}

--- a/logdna/response_types.go
+++ b/logdna/response_types.go
@@ -135,6 +135,7 @@ func mapChannelPagerDuty(channel *channelResponse) map[string]interface{} {
 
 	return c
 }
+
 func mapChannelWebhook(channel *channelResponse) map[string]interface{} {
 	c := make(map[string]interface{})
 


### PR DESCRIPTION
**Note**: Tests are expected to fail currently as the API is not publicly available, but this is ready for review.
**feat(stream): add logdna_stream_config resource**

The `logdna_stream_config` resource manages the Event Streaming
setup for a given account.

Ref: LOG-10208

---

**feat(stream): add logdna_stream_exclusion resource**
 
The `logdna_stream_exclusion` resource manages Event Streaming
exclusions for an account.

Ref: LOG-10207

---

**fix(ci): include the GIT_BRANCH in the postcov step**

Jenkins runs this step in a detacted head state, so the `GIT_BRANCH`
needs to be exposed to the build container in order for the coveralls
coverage report to link to the proper branch.

Also includes HTML coverage report generation in the local test target.
