### PR TITLE
docs: add example for using webhooks with slack

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,9 @@
 
 [![Public Beta](https://img.shields.io/badge/-Public%20Beta-404346?style=flat)](#)
 
-[LogDNA](https://logdna.com) is a centralized log management platform. The LogDNA Terraform Provider allows organizations to manage certain LogDNA resources (alerts, views, etc) programmatically via Terraform.
+[LogDNA](https://logdna.com) is a centralized log management platform. The LogDNA
+Terraform Provider allows organizations to manage certain LogDNA resources
+programmatically via Terraform.
 
 ## Example Usage
 ```hcl
@@ -27,17 +29,39 @@ resource "logdna_view" "http500" {
 
 ## Pre-requirements and considerations
 Before using Terraform for creating resources in LogDNA, review the following notes:
-- Verify Terraform is [installed](https://learn.hashicorp.com/tutorials/terraform/install-cli). The minimum supported version is 0.12.0 and can be checked by running `terraform version`.
-- The configurations seen in the examples will go into a Terraform configuration file such as `main.tf`.
-- Have the service key for your Organization available. To obtain the service key for your LogDNA Organization, go to the LogDNA dashboard and navigate to **Settings > Organization > API Keys** or follow this link [here](https://app.logdna.com/manage/api-keys).
-- Authentication is handled via the `servicekey` parameter and can be set in the `provider` configuration section in the `.tf` file.
-- When using the LogDNA Terraform provider, be aware that there is a rate limit of 50 requests per minute.
-- If you do not provide a specific a `url` in the provider configuration, the URL defaults to `https://api.logdna.com` (recommended).
-- If you want to create an Alert that uses PagerDuty to notify you, you will need to provide LogDNA with the [PagerDuty API key](https://support.pagerduty.com/docs/generating-api-keys#events-api-keys). To ensure that the LogDNA Dashboard properly displays the PagerDuty alert notification channel, we recommend that you first link the PagerDuty service to LogDNA via the [Dashboard UI](https://docs.logdna.com/docs/pagerduty-alert-integration) before using this plugin to create a PagerDuty Alert. You may choose to create such resources first and then link PagerDuty, but be aware that they will not work as intended until the connection is reconciled.
+- Verify Terraform is
+  [installed](https://learn.hashicorp.com/tutorials/terraform/install-cli).
+  The minimum supported version is 0.12.0 and can be checked by running
+  `terraform version`.
+- The configurations seen in the examples will go into a Terraform configuration file such
+  as `main.tf`.
+- Have the service key for your Organization available. To obtain the service key for your
+  LogDNA Organization, go to the LogDNA dashboard and navigate to **Settings >
+  Organization > API Keys** or follow this link
+  [here](https://app.logdna.com/manage/api-keys).
+- Authentication is handled via the `servicekey` parameter and can be set in the
+  `provider` configuration section in the `.tf` file.
+- When using the LogDNA Terraform provider, be aware that there is a rate limit of 50
+  requests per minute.
+- If you do not provide a specific a `url` in the provider configuration, the URL defaults
+  to `https://api.logdna.com` (recommended).
+- If you want to create an Alert that uses PagerDuty to notify you, you will need to
+  provide LogDNA with the
+  [PagerDuty API key](https://support.pagerduty.com/docs/generating-api-keys#events-api-keys).
+  To ensure that the LogDNA Dashboard properly displays the PagerDuty alert notification
+  channel, we recommend that you first link the PagerDuty service to LogDNA via the
+  [Dashboard UI](https://docs.logdna.com/docs/pagerduty-alert-integration) before using
+  this plugin to create a PagerDuty Alert. You may choose to create such resources first
+  and then link PagerDuty, but be aware that they will not work as intended until the
+  connection is reconciled.
 
 ## Argument Reference
 
 The following arguments are supported by the `provider` section of the `.tf` file:
 
-- `servicekey`: **string _(Required)_** LogDNA Account Service Key. This can be generated or retrieved from Settings > Organization > API Keys.
-- `url`: **string** _(Optional; Default: api.logdna.com)_ The LogDNA region URL. If you’re configuring an IBM Log Analysis with LogDNA or IBM Cloud Activity Tracker with LogDNA, you’ll need to ensure `url` is set to the [correct endpoint depending on the IBM region](https://cloud.ibm.com/docs/Log-Analysis-with-LogDNA?topic=Log-Analysis-with-LogDNA-endpoints#endpoints_api).
+- `servicekey`: **string _(Required)_** LogDNA Account Service Key. This can be generated
+  or retrieved from Settings > Organization > API Keys.
+- `url`: **string** _(Optional; Default: api.logdna.com)_ The LogDNA region URL. If you’re
+  configuring an IBM Log Analysis with LogDNA or IBM Cloud Activity Tracker with LogDNA,
+  you’ll need to ensure `url` is set to the
+  [correct endpoint depending on the IBM region](https://cloud.ibm.com/docs/Log-Analysis-with-LogDNA?topic=Log-Analysis-with-LogDNA-endpoints#endpoints_api).

--- a/docs/resources/logdna_alert.md
+++ b/docs/resources/logdna_alert.md
@@ -1,8 +1,12 @@
 # Resource: `logdna_alert`
 
-Manages [LogDNA Preset Alerts](https://docs.logdna.com/docs/alerts). Preset Alerts are alerts that you can define separately from a specific View. Preset Alerts can be created standalone and then attached (or detached) to any View, as opposed to View-specific Alerts, which are created specifically for a certain View.
+Manages [LogDNA Preset Alerts](https://docs.logdna.com/docs/alerts). Preset Alerts are 
+alerts that you can define separately from a specific View. Preset Alerts can be created 
+standalone and then attached (or detached) to any View, as opposed to View-specific 
+Alerts, which are created specifically for a certain View.
 
-To get started, all you need to do is to specify a `name` and configuration for one of our currently supported alerts: email, webhook, or PagerDuty.
+To get started, all you need to do is to specify a `name` and configuration for one of
+our currently supported alerts: email, webhook, or PagerDuty.
 
 ## Example - Basic Preset Alert
 
@@ -94,37 +98,78 @@ The following arguments are supported by `logdna_alert`:
 
 `email_channel` supports the following arguments:
 
-- `emails`: **_[]string (Required)_** An array of email addresses (strings) to notify in the Alert
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
-- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
-- `timezone`: **_string_** _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
-- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `emails`: **_[]string (Required)_** An array of email addresses (strings) to notify in 
+  the Alert
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Valid options are `"true"` 
+  and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will 
+  trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger
+  after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 
+  30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for
+  absence Alerts.
+- `timezone`: **_string_** _(Optional)_ Which time zone the log timestamps will be
+  formatted in. Timezones are represented as
+  [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for 
+  absence)_ Interval which the Alert will be looking for presence or absence of log lines.
+  For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, 
+  `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered
+  (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were
+  not seen in the `triggerinterval`).
 
 ### pagerduty_channel
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will 
+  trigger immediately after the trigger limit is reached. Valid options are `"true"` and
+  `"false"` for presence Alerts and `"false"` for absence Alerts.
 - `key`: **_string (Required)_** The PagerDuty service key.
-- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
-- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
-- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will 
+  trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger
+  after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after
+  30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for
+  absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for
+  absence)_ Interval which the Alert will be looking for presence or absence of log lines.
+  For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered
+  (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were
+  not seen in the `triggerinterval`).
 
 ### webhook_channel
 
 `webhook_channel` supports the following arguments:
 
-- `bodytemplate`: **_string_** _(Optional)_ JSON-formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string.
-- `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request headers and header values. Example: `"MyHeader" = "MyValue"`
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
-- `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
-- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
-- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
-- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `bodytemplate`: **_string_** _(Optional)_ JSON-formatted string for the body of the
+  webhook. We recommend using
+  [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html)
+  to easily convert a Terraform map into a JSON string.
+- `headers`: **_map<string,string>** _(Optional)_ Key-value pair for webhook request
+  headers and header values. Example: `"MyHeader" = "MyValue"`
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will
+  trigger immediately after the trigger limit is reached. Valid options are `"true"` and
+  `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook
+  request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will
+  trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger
+  after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after
+  30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for
+  absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for
+  absence)_ Interval which the Alert will be looking for presence or absence of log lines.
+  For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered
+  (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were
+  not seen in the `triggerinterval`).
 - `url`: **_string (Required)_** The URL of the webhook.
-
-

--- a/docs/resources/logdna_view.md
+++ b/docs/resources/logdna_view.md
@@ -1,6 +1,11 @@
 # Resource: `logdna_view`
 
-Manages [LogDNA Views](https://docs.logdna.com/docs/views) as well as [View-specific Alerts](https://docs.logdna.com/docs/alerts#how-to-attach-an-alert-to-an-existing-view). These differ from `logdna_alert` which are "preset alerts", while these are specific to certain views.  To get started, specify a `name` and one of: `apps`, `hosts`, `levels`, `query` or `tags`. We currently support configuring these view alerts to be sent via email, webhook, or PagerDuty.
+Manages [LogDNA Views](https://docs.logdna.com/docs/views) as well as
+[View-specific Alerts](https://docs.logdna.com/docs/alerts#how-to-attach-an-alert-to-an-existing-view).
+These differ from `logdna_alert` which are "preset alerts", while these are specific to
+certain views.  To get started, specify a `name` and one of: `apps`, `hosts`, `levels`,
+`query` or `tags`. We currently support configuring these view alerts to be sent via
+email, webhook, or PagerDuty.
 
 ## Example - Basic View
 
@@ -83,10 +88,13 @@ Note that only the alert channels supported by this provider will be imported.
 
 The following arguments are supported by `logdna_view`:
 
-_Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, `levels`, `query`, `tags` must be specified to create a View.
+_Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, `levels`,
+`query`, `tags` must be specified to create a View.
 
 - `apps`: **_string_** _(Optional)_ Array of app names to filter the View by.
-- `categories`: **[]string** _(Optional)_ Array of existing category names that this View should be nested under. _Note: If the category does not exist, the View will by default be created in uncategorized_.
+- `categories`: **[]string** _(Optional)_ Array of existing category names that this View
+  should be nested under. _Note: If the category does not exist, the View will by default
+  be created in uncategorized_.
 - `hosts`: **[]string** _(Optional)_ Array of host names to filter the View by.
 - `levels`: **[]string** _(Optional)_ Array of level names to filter the View by.
 - `name`: **string _(Required)_** The name of this View.
@@ -97,35 +105,80 @@ _Note:_ A `name` and at least one of the following properties: `apps`, `hosts`, 
 
 `email_channel` supports the following arguments:
 
-- `emails`: **[]string _(Required)_** An array of email addresses (strings) to notify in the Alert
-- `immediate`: **string** _(Optional; Default: `"false"`)_ Whether the Alert will be triggered immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
-- `operator`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
-- `timezone`: **string** _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
-- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `emails`: **[]string _(Required)_** An array of email addresses (strings) to notify in
+  the Alert
+- `immediate`: **string** _(Optional; Default: `"false"`)_ Whether the Alert will be
+  triggered immediately after the trigger limit is reached. Valid options are `"true"` and
+  `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `operator`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for
+  absence)_ Whether the Alert will trigger on the presence or absence of logs. Valid
+  options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger
+  after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after
+  30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for
+  absence Alerts.
+- `timezone`: **string** _(Optional)_ Which time zone the log timestamps will be formatted
+  in. Timezones are represented as
+  [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for
+  absence)_ Interval which the Alert will be looking for presence or absence of log lines.
+  For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered
+  (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were
+  not seen in the `triggerinterval`).
 
 ### pagerduty_channel
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will be triggered immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts, and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will be
+  triggered immediately after the trigger limit is reached. Valid options are `"true"` and
+  `"false"` for presence Alerts, and `"false"` for absence Alerts.
 - `key`: **string _(Required)_** The service key used for PagerDuty.
-- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
-- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
-- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will
+  trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger
+  after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after
+  30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for
+  absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for
+  absence)_ Interval which the Alert will be looking for presence or absence of log lines.
+  For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered
+  (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were
+  not seen in the `triggerinterval`).
 
 ### webhook_channel
 
 `webhook_channel` supports the following arguments:
 
-- `bodytemplate`: **string** _(Optional)_ JSON-formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string.
-- `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request headers and header values. Example: `"MyHeader" = "MyValue"`
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts, and `"false"` for absence Alerts.
-- `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
-- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
-- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
-- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`)
+- `bodytemplate`: **string** _(Optional)_ JSON-formatted string for the body of the
+  webhook. We recommend using
+  [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html)
+  to easily convert a Terraform map into a JSON string.
+- `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request
+  headers and header values. Example: `"MyHeader" = "MyValue"`
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will
+  trigger immediately after the trigger limit is reached. Valid options are `"true"` and
+  `"false"` for presence Alerts, and `"false"` for absence Alerts.
+- `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook
+  request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will
+  trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger
+  after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after
+  30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for
+  absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for 
+  absence)_ Interval which the Alert will be looking for presence or absence of log lines.
+  For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`,
+  `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered.
+  (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were
+  not seen in the `triggerinterval`)
 - `url`: **_string (Required)_** The URL of the webhook.

--- a/examples/view_with_webhook_alert_for_slack.tf
+++ b/examples/view_with_webhook_alert_for_slack.tf
@@ -1,0 +1,22 @@
+# Slack Alerts can be configured by using the Webhook channel in conjunction with
+# a channel-specific webhook URL
+# https://slack.com/help/articles/115005265063-Incoming-webhooks-for-Slack
+
+provider "logdna" {
+  servicekey = "Your service key goes here"
+}
+
+resource "logdna_view" "my_view_with_slack_alert" {
+  name       = "Slack Alert"
+  query      = "test"
+
+  webhook_channel {
+    immediate       = "false"
+    method          = "post"
+    # Your unique Slack webhook URL
+    url             = "https://hooks.slack.com/services/XXXXX/XXXXX/XXXXX"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+  }
+}


### PR DESCRIPTION
This adds an example of using the `webhook` channel with
a Slack webhook URL, which enables the same integration that is
offered by the UI without manually connecting or authorizing the
LogDNA instance against Slack.

Ref: LOG-10472

---

Also reformats the documentation to keep lines ~90 columns. 