### PR TITLE
feat(alerts): add preset alert `logdna_alert` as a data source

### DIFF
--- a/docs/data-sources/logdna_alert.md
+++ b/docs/data-sources/logdna_alert.md
@@ -1,0 +1,66 @@
+# Data Source: `logdna_alert`
+
+Pulls in the relevant details from existing [LogDNA Preset Alerts](https://docs.logdna.com/docs/alerts). The `logdna_alert` _data source_ remotely fetches the information from a preset alert using its ID. This preset alert may or may not be directly managed by Terraform. For the management of preset alerts as Terraform _resources_, refer to the documentation [here](../resources/logdna_alert.md).
+
+Users can opt to reference certain preset alerts as data sources rather than definining them as resources. In this scenario, the preset alerts are not be managed as Terraform _resources_ but the data can still be accessed and referenced in other modules.
+
+To create a `logdna_alert` data source, the `presetid` argument must be provided in its declaration to ensure the data being read remotely is correct.
+
+## Example Usage
+
+```hcl
+provider "logdna" {
+  servicekey = "xxxxxxxxxxxxxxxxxxxxxxxx"
+  url = "https://api.logdna.com" # (Optional) specify a LogDNA region
+}
+
+resource "logdna_alert" "managed" {
+  name = "My Preset Alert via Terraform"
+  email_channel {
+    emails          = ["test@logdna.com"]
+    immediate       = "false"
+    operator        = "presence"
+    triggerlimit    = 15
+    triggerinterval = "15m"
+    terminal        = "true"
+    timezone        = "Pacific/Samoa"
+  }
+}
+
+# create data source by referencing the ID from an alert declared in the same config
+data "logdna_alert" "managed_remote" {
+  presetid = logdna_alert.managed.id
+}
+
+# create data source by pulling in the details from an alert associated with the ID
+data "logdna_alert" "external_remote" {
+  presetid = "xxxxxxxxxx" # the associated ID can be grabbed from the Web UI, API calls, Terraform config, etc
+}
+
+# pass in data source attributes as arguments for module(s) declared in the same config
+resource "logdna_view" "test" {
+  name  = "Basic View"
+  query = "level:debug my query"
+
+  email_channel = data.logdna_alert.managed_remote.email_channel
+  pagerduty_channel = data.logdna_alert.external_remote.pagerduty_channel
+  webhook_channel = data.logdna_alert.external_remote.webhook_channel
+}
+```
+
+## Argument Reference
+
+The `logdna_alert` data source supports (and requires) the following argument:
+
+- `presetid`: (Required) The ID associated with a specific preset alert from which we will be pulling details
+
+## Attribute Reference
+
+The `logdna_alert` data source exposes the same attributes supported as arguments in the managed resource. For more detailed descriptions, refer to the documentation [here](../resources/logdna_alert.md#Argument+Reference).
+
+The following attributes (if they exist) can be referenced in the `logdna_alert` data source:
+
+- `name`: Name of the given preset alert
+- `email_channel`: List of notifications configured via email in the given preset alert
+- `pagerduty_channel`: List of notifications configured via PagerDuty in the given preset alert
+- `webhook_channel`: List of notifications configured via webhook(s) in the given preset alert

--- a/logdna/data_source_alert.go
+++ b/logdna/data_source_alert.go
@@ -1,0 +1,150 @@
+package logdna
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var schemaStr = &schema.Schema{
+	Type:     schema.TypeInt,
+	Computed: true,
+}
+var schemaInt = &schema.Schema{
+	Type:     schema.TypeString,
+	Computed: true,
+}
+var alertProps = map[string]*schema.Schema{
+	"immediate":       schemaInt,
+	"operator":        schemaInt,
+	"terminal":        schemaInt,
+	"triggerinterval": schemaInt,
+	"triggerlimit":    schemaStr,
+}
+
+func dataSourceAlertRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	pc := m.(*providerConfig)
+	id := d.Get("presetid").(string)
+
+	req := newRequestConfig(
+		pc,
+		"GET",
+		fmt.Sprintf("/v1/config/presetalert/%s", id),
+		nil,
+	)
+
+	body, err := req.MakeRequest()
+
+	log.Printf("[DEBUG] GET presetalert raw response body %s\n", body)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot read the remote presetalert resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+
+	alert := alertResponse{}
+	err = json.Unmarshal(body, &alert)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  "Cannot unmarshal response from the remote presetalert resource",
+			Detail:   err.Error(),
+		})
+		return diags
+	}
+	log.Printf("GET presetalert structure is as follows: %+v\n", alert)
+
+	appendError(d.Set("name", alert.Name), &diags)
+
+	ints, diags := alert.MapChannelsToSchema()
+	log.Printf("[DEBUG] presetalert MapChannelsToSchema result: %+v\n", ints)
+
+	for name, value := range ints {
+		if len(value) == 0 {
+			continue
+		}
+
+		key := fmt.Sprintf("%s_channel", name)
+		appendError(d.Set(key, value), &diags)
+	}
+
+	d.SetId(id)
+	return diags
+}
+
+func dataSourceAlert() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceAlertRead,
+		Schema: map[string]*schema.Schema{
+			"presetid": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": schemaInt,
+			"email_channel": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: getAlertSchema("email"),
+				},
+				Computed: true,
+			},
+			"pagerduty_channel": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: getAlertSchema("pagerduty"),
+				},
+				Computed: true,
+			},
+			"webhook_channel": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: getAlertSchema("webhook"),
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func getAlertSchema(chanl string) map[string]*schema.Schema {
+	schma := map[string]*schema.Schema{}
+	for key, value := range alertProps {
+		schma[key] = value
+	}
+
+	switch chanl {
+	case "email":
+		schma["timezone"] = schemaInt
+		schma["emails"] = &schema.Schema{
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Computed: true,
+		}
+	case "pagerduty":
+		schma["key"] = schemaInt
+	case "webhook":
+		schma["bodytemplate"] = schemaInt
+		schma["method"] = schemaInt
+		schma["url"] = schemaInt
+		schma["headers"] = &schema.Schema{
+			Type: schema.TypeMap,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Computed: true,
+		}
+	}
+
+	return schma
+}

--- a/logdna/data_source_alert_test.go
+++ b/logdna/data_source_alert_test.go
@@ -1,0 +1,218 @@
+package logdna
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const pcStr = `
+provider "logdna" {
+	servicekey = "%s"
+}
+`
+const rsStr = `
+resource "logdna_alert" "test" {
+	name = "%s"
+	%s
+}
+`
+const rsStrMultiple = `
+resource "logdna_alert" "test" {
+	name = "%s"
+	%s
+	%s
+	%s
+}
+`
+const dsStr = `
+data "logdna_alert" "remote" {
+	presetid = logdna_alert.test.id
+}
+`
+const email = `
+	email_channel {
+		emails          = ["test@logdna.com"]
+		immediate       = "false"
+		operator        = "presence"
+		triggerlimit    = 15
+		triggerinterval = "15m"
+		terminal        = "true"
+		timezone        = "Pacific/Samoa"
+	}
+`
+const pagerduty = `
+	pagerduty_channel {
+		immediate       = "false"
+		key             = "Your PagerDuty API key goes here"
+		terminal        = "true"
+		triggerinterval = "15m"
+		triggerlimit    = 15
+	}
+`
+const webhook = `
+	webhook_channel {
+		headers = {
+			hello = "test3"
+			test  = "test2"
+		}
+		bodytemplate = jsonencode({
+		fields = {
+			description = "{{ matches }} matches found for {{ name }}"
+			issuetype = {
+				name = "Bug"
+			}
+			project = {
+				key = "test"
+			},
+			summary = "Alert From {{ name }}"
+		}
+		})
+		immediate       = "false"
+		method          = "post"
+		url             = "https://yourwebhook/endpoint"
+		terminal        = "true"
+		triggerinterval = "15m"
+		triggerlimit    = 15
+	}
+`
+
+func TestDataSourceAlert_basicEmail(t *testing.T) {
+	data := "data.logdna_alert.remote"
+	rsName := "test"
+
+	args := []string{rsName, email}
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlertConfig(args...),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists(data),
+					resource.TestCheckResourceAttr(data, "name", rsName),
+					resource.TestCheckResourceAttr(data, "email_channel.#", "1"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.%", "7"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.emails.#", "1"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.emails.0", "test@logdna.com"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.operator", "presence"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.timezone", "Pacific/Samoa"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr(data, "email_channel.0.triggerlimit", "15"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceAlert_basicPagerDuty(t *testing.T) {
+	data := "data.logdna_alert.remote"
+	rsName := "test"
+
+	args := []string{rsName, pagerduty}
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlertConfig(args...),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists(data),
+					resource.TestCheckResourceAttr(data, "name", rsName),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.#", "1"),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.%", "6"),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.operator", "presence"),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.triggerlimit", "15"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceAlert_basicWebhook(t *testing.T) {
+	data := "data.logdna_alert.remote"
+	rsName := "test"
+
+	args := []string{rsName, webhook}
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlertConfig(args...),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists(data),
+					resource.TestCheckResourceAttr(data, "name", rsName),
+					resource.TestCheckResourceAttr(data, "webhook_channel.#", "1"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.%", "9"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.headers.%", "2"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.headers.hello", "test3"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.headers.test", "test2"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert From {{ name }}\"\n  }\n}"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.method", "post"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.url", "https://yourwebhook/endpoint"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr(data, "webhook_channel.0.triggerlimit", "15"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceAlert_multipleChannels(t *testing.T) {
+	data := "data.logdna_alert.remote"
+	rsName := "test"
+
+	args := []string{rsName, "multiple"}
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceAlertConfig(args...),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists(data),
+					resource.TestCheckResourceAttr(data, "name", rsName),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceAlertConfig(args ...string) string {
+	name := args[0]
+	integration := args[1]
+	isMultiple := false
+	if integration == "multiple" {
+		isMultiple = true
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, pcStr, serviceKey)
+
+	if isMultiple {
+		fmt.Fprintf(&sb, rsStrMultiple, name, email, pagerduty, webhook)
+	} else {
+		fmt.Fprintf(&sb, rsStr, name, integration)
+	}
+
+	sb.WriteString(dsStr)
+	return sb.String()
+}
+
+func testDataSourceAlertExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		return nil
+	}
+}

--- a/logdna/provider.go
+++ b/logdna/provider.go
@@ -27,6 +27,9 @@ func Provider() *schema.Provider {
 				Default:  "https://api.logdna.com",
 			},
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"logdna_alert": dataSourceAlert(),
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"logdna_alert":            resourceAlert(),
 			"logdna_view":             resourceView(),


### PR DESCRIPTION
Creates a `logdna_alert` data source which provides support for
remotely fetching information from existing preset alerts. Added
tests, updated the documentation, and included it in the provider.

Semver: minor
Ref: LOG-10590