### PR TITLE
fix(stream_exclusion_rule): set `title` property to optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ install-local: build-local
 	cp ${BIN_DIR}/${BIN} ${TARGET_DIR}/${PROJECT}
 
 lint:
+	mkdir -p $(COVERAGE_DIR)
 	$(LINT_CMD)
 
 test-local: .env-SERVICE_KEY lint
@@ -56,7 +57,6 @@ test: .env-SERVICE_KEY build-image lint
 
 testcov: BUILD_FLAGS:=--env SERVICE_KEY --env TF_ACC=1 
 testcov: .env-SERVICE_KEY build-image lint
-	mkdir -p $(COVERAGE_DIR)
 	$(BUILD_ENV) go test $(TEST) -v $(TEST_ARGS) -coverprofile $(COVERAGE_FILE)
 	$(BUILD_ENV) go tool cover -html $(COVERAGE_FILE) -o $(COVERAGE_FILE).html
 

--- a/logdna/resource_stream_exclusion.go
+++ b/logdna/resource_stream_exclusion.go
@@ -161,7 +161,8 @@ func resourceStreamExclusion() *schema.Resource {
 			},
 			"title": {
 				Type:     schema.TypeString,
-				Required: true,
+				Default:  nil,
+				Optional: true,
 			},
 			"active": {
 				Type:     schema.TypeBool,

--- a/logdna/resource_stream_exclusion_test.go
+++ b/logdna/resource_stream_exclusion_test.go
@@ -36,13 +36,6 @@ func TestStreamExclusion_expectInvalidError(t *testing.T) {
 			},
 			{
 				Config: testStreamExclusion(`
-					title = ""
-					query = "test-query"
-				`, ""),
-				ExpectError: regexp.MustCompile(`\\"title\\" is not allowed to be empty`),
-			},
-			{
-				Config: testStreamExclusion(`
 					title = "test-title"
 					apps = []
 				`, ""),


### PR DESCRIPTION
The exclusion rules created for Event Streaming configurations al-
ready have IDs which can be used as reference properties. To match
the behavor in our webapp, we opted to update the schemas on API +
TF to set the `title` property to optional. In the UI, the title
can be omitted which will still result in the creation of a valid
exclusion rule. This commit aligns the TF behavior with web.

Semver: patch
Ref: LOG-10750