### PR TITLE
[LOG-10589] feat: add slack integration to alerts & views

### DIFF
--- a/docs/data-sources/logdna_alert.md
+++ b/docs/data-sources/logdna_alert.md
@@ -25,6 +25,39 @@ resource "logdna_alert" "managed" {
     terminal        = "true"
     timezone        = "Pacific/Samoa"
   }
+
+  pagerduty_channel {
+    immediate       = "true"
+    key             = "Your PagerDuty API key goes here"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+  }
+
+  slack_channel {
+    immediate       = "false"
+    operator        = "absence"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+    url             = "https://hooks.slack.com/services/identifier/secret"
+  }
+
+  webhook_channel {
+    bodytemplate = jsonencode({
+      message = "Alerts from {{name}}"
+    })
+    headers = {
+      "Authentication" = "auth_header_value"
+      "HeaderTwo"      = "ValueTwo"
+    }
+    immediate       = "false"
+    method          = "post"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+    url             = "https://yourwebhook/endpoint"
+ }
 }
 
 # create data source by referencing the ID from an alert declared in the same config
@@ -44,6 +77,7 @@ resource "logdna_view" "test" {
 
   email_channel = data.logdna_alert.managed_remote.email_channel
   pagerduty_channel = data.logdna_alert.external_remote.pagerduty_channel
+  slack_channel = data.logdna_alert.external_remote.slack_channel
   webhook_channel = data.logdna_alert.external_remote.webhook_channel
 }
 ```
@@ -63,4 +97,5 @@ The following attributes (if they exist) can be referenced in the `logdna_alert`
 - `name`: Name of the given preset alert
 - `email_channel`: List of notifications configured via email in the given preset alert
 - `pagerduty_channel`: List of notifications configured via PagerDuty in the given preset alert
+- `slack_channel`: List of notifications configured via Slack in the given preset alert
 - `webhook_channel`: List of notifications configured via webhook(s) in the given preset alert

--- a/docs/resources/logdna_alert.md
+++ b/docs/resources/logdna_alert.md
@@ -24,9 +24,8 @@ resource "logdna_alert" "my_alert" {
     timezone        = "Pacific/Samoa"
   }
 }
-
-
 ```
+
 ## Example - Multi-channel Preset Alert
 
 ```hcl
@@ -55,6 +54,15 @@ resource "logdna_alert" "my_alert" {
     triggerlimit    = 15
   }
 
+  slack_channel {
+    immediate       = "false"
+    operator        = "absence"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+    url             = "https://hooks.slack.com/services/identifier/secret"
+  }
+
   webhook_channel {
     bodytemplate = jsonencode({
       message = "Alerts from {{name}}"
@@ -79,7 +87,7 @@ Preset Alerts can be imported by `id`, which can be found in the URL when editin
 Preset Alert in the web UI:
 
 ```sh
-$ terraform import logdna_alert.your-alert-name <id>
+terraform import logdna_alert.your-alert-name <id>
 ```
 
 Note that only the alert channels supported by this provider will be imported.
@@ -113,6 +121,16 @@ The following arguments are supported by `logdna_alert`:
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 
+### slack_channel
+
+`slack_channel` supports the following arguments:
+
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `url`: **_string (Required)_** The URL of the webhook for a given Slack application/integration (& channel).
+
 ### webhook_channel
 
 `webhook_channel` supports the following arguments:
@@ -126,5 +144,3 @@ The following arguments are supported by `logdna_alert`:
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, and `24h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 - `url`: **_string (Required)_** The URL of the webhook.
-
-

--- a/logdna/common_test.go
+++ b/logdna/common_test.go
@@ -1,0 +1,141 @@
+package logdna
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const tmplPc = `provider "logdna" {
+	%s
+}`
+const tmplRs = `%s %q %q {
+%s
+}`
+
+var nilLst = []string{}
+var nilOpt = map[string]map[string]string{}
+
+var rsDefaults = map[string]map[string]string{
+	"alert": {
+		"name": `"test"`,
+	},
+	"view": {
+		"apps":       "",
+		"categories": "",
+		"hosts":      "",
+		"levels":     "",
+		"name":       `"test"`,
+		"query":      `"test"`,
+		"tags":       "",
+	},
+}
+var chnlDefaults = map[string]map[string]string{
+	"email": {
+		"emails":          `["test@logdna.com"]`,
+		"immediate":       `"false"`,
+		"operator":        `"absence"`,
+		"terminal":        `"true"`,
+		"timezone":        `"Pacific/Samoa"`,
+		"triggerinterval": `"15m"`,
+		"triggerlimit":    `15`,
+	},
+	"pagerduty": {
+		"immediate":       `"false"`,
+		"operator":        `"presence"`,
+		"key":             `"Your PagerDuty API key goes here"`,
+		"terminal":        `"true"`,
+		"triggerinterval": `"15m"`,
+		"triggerlimit":    `15`,
+	},
+	"slack": {
+		"immediate":       `"false"`,
+		"operator":        `"absence"`,
+		"terminal":        `"true"`,
+		"triggerinterval": `"30m"`,
+		"triggerlimit":    `15`,
+		"url":             `"https://hooks.slack.com/services/identifier/secret"`,
+	},
+	"webhook": {
+		"headers": "{\n" +
+			"\t\t\thello = \"test3\"\n" +
+			"\t\t\ttest = \"test2\"\n" +
+			"\t\t}",
+		"bodytemplate": `jsonencode({
+				fields = {
+					description = "{{ matches }} matches found for {{ name }}"
+					issuetype = {
+						name = "Bug"
+					}
+					project = {
+						key = "test"
+					}
+					summary = "Alert from {{ name }}"
+				}
+			})`,
+		"immediate":       `"false"`,
+		"method":          `"post"`,
+		"operator":        `"presence"`,
+		"terminal":        `"true"`,
+		"triggerinterval": `"15m"`,
+		"triggerlimit":    `15`,
+		"url":             `"https://yourwebhook/endpoint"`,
+	},
+}
+
+func cloneDefaults(dfts map[string]string) map[string]string {
+	clone := make(map[string]string)
+	for k, v := range dfts {
+		clone[k] = v
+	}
+	return clone
+}
+
+func fmtTestConfigResource(objTyp, rsName string, pcArgs []string, rsArgs map[string]string, chArgs map[string]map[string]string) string {
+	pc := fmtProviderBlock(pcArgs...)
+	rs := fmtResourceBlock(objTyp, rsName, rsArgs, chArgs)
+	return fmt.Sprintf("%s\n%s", pc, rs)
+}
+
+func fmtProviderBlock(args ...string) string {
+	opts := []string{serviceKey, ""}
+	copy(opts, args)
+	sk, ul := opts[0], opts[1]
+
+	pcCfg := fmt.Sprintf(`servicekey = %q`, sk)
+	if ul != "" {
+		pcCfg = pcCfg + fmt.Sprintf("\n\turl = %q", ul)
+	}
+
+	return fmt.Sprintf(tmplPc, pcCfg)
+}
+
+func fmtResourceBlock(objTyp, rsName string, rsArgs map[string]string, chArgs map[string]map[string]string) string {
+	var rsCfg strings.Builder
+	fmt.Fprint(&rsCfg, fmtBlockArgs(1, rsArgs))
+
+	rgxDgt := regexp.MustCompile(`\d+`)
+	for chName, chArgs := range chArgs {
+		fmt.Fprintf(&rsCfg, "\t%s_channel {\n", rgxDgt.ReplaceAllString(chName, ""))
+		fmt.Fprint(&rsCfg, fmtBlockArgs(2, chArgs))
+		fmt.Fprintf(&rsCfg, "\t}\n")
+	}
+
+	rsType := fmt.Sprintf("logdna_%s", objTyp)
+	return fmt.Sprintf(tmplRs, "resource", rsType, rsName, rsCfg.String())
+}
+
+func fmtBlockArgs(nstLvl int, opts map[string]string) string {
+	var numTab strings.Builder
+	for i := 0; i < nstLvl; i++ {
+		fmt.Fprint(&numTab, "\t")
+	}
+	tabs := numTab.String()
+	var blkCfg strings.Builder
+	for arg, val := range opts {
+		if val != "" {
+			fmt.Fprintf(&blkCfg, "%s%s = %s\n", tabs, arg, val)
+		}
+	}
+	return blkCfg.String()
+}

--- a/logdna/data_source_alert.go
+++ b/logdna/data_source_alert.go
@@ -10,20 +10,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var schemaStr = &schema.Schema{
+var intSchema = &schema.Schema{
 	Type:     schema.TypeInt,
 	Computed: true,
 }
-var schemaInt = &schema.Schema{
+var strSchema = &schema.Schema{
 	Type:     schema.TypeString,
 	Computed: true,
 }
 var alertProps = map[string]*schema.Schema{
-	"immediate":       schemaInt,
-	"operator":        schemaInt,
-	"terminal":        schemaInt,
-	"triggerinterval": schemaInt,
-	"triggerlimit":    schemaStr,
+	"immediate":       strSchema,
+	"operator":        strSchema,
+	"terminal":        strSchema,
+	"triggerinterval": strSchema,
+	"triggerlimit":    intSchema,
 }
 
 func dataSourceAlertRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -89,7 +89,7 @@ func dataSourceAlert() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"name": schemaInt,
+			"name": strSchema,
 			"email_channel": {
 				Type: schema.TypeList,
 				Elem: &schema.Resource{
@@ -104,6 +104,13 @@ func dataSourceAlert() *schema.Resource {
 				},
 				Computed: true,
 			},
+			"slack_channel": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: getAlertSchema("slack"),
+				},
+				Computed: true,
+			},
 			"webhook_channel": {
 				Type: schema.TypeList,
 				Elem: &schema.Resource{
@@ -115,15 +122,15 @@ func dataSourceAlert() *schema.Resource {
 	}
 }
 
-func getAlertSchema(chanl string) map[string]*schema.Schema {
+func getAlertSchema(chnl string) map[string]*schema.Schema {
 	schma := map[string]*schema.Schema{}
 	for key, value := range alertProps {
 		schma[key] = value
 	}
 
-	switch chanl {
+	switch chnl {
 	case "email":
-		schma["timezone"] = schemaInt
+		schma["timezone"] = strSchema
 		schma["emails"] = &schema.Schema{
 			Type: schema.TypeList,
 			Elem: &schema.Schema{
@@ -131,12 +138,14 @@ func getAlertSchema(chanl string) map[string]*schema.Schema {
 			},
 			Computed: true,
 		}
+	case "slack":
+		schma["url"] = strSchema
 	case "pagerduty":
-		schma["key"] = schemaInt
+		schma["key"] = strSchema
 	case "webhook":
-		schma["bodytemplate"] = schemaInt
-		schma["method"] = schemaInt
-		schma["url"] = schemaInt
+		schma["bodytemplate"] = strSchema
+		schma["method"] = strSchema
+		schma["url"] = strSchema
 		schma["headers"] = &schema.Schema{
 			Type: schema.TypeMap,
 			Elem: &schema.Schema{

--- a/logdna/data_source_alert_test.go
+++ b/logdna/data_source_alert_test.go
@@ -2,208 +2,161 @@ package logdna
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-const pcStr = `
-provider "logdna" {
-	servicekey = "%s"
-}
-`
-const rsStr = `
-resource "logdna_alert" "test" {
-	name = "%s"
-	%s
-}
-`
-const rsStrMultiple = `
-resource "logdna_alert" "test" {
-	name = "%s"
-	%s
-	%s
-	%s
-}
-`
-const dsStr = `
+const ds = `
 data "logdna_alert" "remote" {
 	presetid = logdna_alert.test.id
 }
 `
-const email = `
-	email_channel {
-		emails          = ["test@logdna.com"]
-		immediate       = "false"
-		operator        = "presence"
-		triggerlimit    = 15
-		triggerinterval = "15m"
-		terminal        = "true"
-		timezone        = "Pacific/Samoa"
-	}
-`
-const pagerduty = `
-	pagerduty_channel {
-		immediate       = "false"
-		key             = "Your PagerDuty API key goes here"
-		terminal        = "true"
-		triggerinterval = "15m"
-		triggerlimit    = 15
-	}
-`
-const webhook = `
-	webhook_channel {
-		headers = {
-			hello = "test3"
-			test  = "test2"
-		}
-		bodytemplate = jsonencode({
-		fields = {
-			description = "{{ matches }} matches found for {{ name }}"
-			issuetype = {
-				name = "Bug"
-			}
-			project = {
-				key = "test"
-			},
-			summary = "Alert From {{ name }}"
-		}
-		})
-		immediate       = "false"
-		method          = "post"
-		url             = "https://yourwebhook/endpoint"
-		terminal        = "true"
-		triggerinterval = "15m"
-		triggerlimit    = 15
-	}
-`
 
-func TestDataSourceAlert_basicEmail(t *testing.T) {
-	data := "data.logdna_alert.remote"
-	rsName := "test"
+func TestDataAlert_BulkChannels(t *testing.T) {
+	emArgs := map[string]map[string]string{
+		"email":  cloneDefaults(chnlDefaults["email"]),
+		"email1": cloneDefaults(chnlDefaults["email"]),
+	}
+	emsCfg := fmtTestConfigResource("alert", "test", nilLst, alertDefaults, emArgs)
 
-	args := []string{rsName, email}
+	pdArgs := map[string]map[string]string{
+		"pagerduty":  cloneDefaults(chnlDefaults["pagerduty"]),
+		"pagerduty1": cloneDefaults(chnlDefaults["pagerduty"]),
+	}
+	pdsCfg := fmtTestConfigResource("alert", "test", nilLst, alertDefaults, pdArgs)
+
+	slArgs := map[string]map[string]string{
+		"slack":  cloneDefaults(chnlDefaults["slack"]),
+		"slack1": cloneDefaults(chnlDefaults["slack"]),
+	}
+	slsCfg := fmtTestConfigResource("alert", "test", nilLst, alertDefaults, slArgs)
+
+	wbArgs := map[string]map[string]string{
+		"webhook":  cloneDefaults(chnlDefaults["webhook"]),
+		"webhook1": cloneDefaults(chnlDefaults["webhook"]),
+	}
+	wbsCfg := fmtTestConfigResource("alert", "test", nilLst, alertDefaults, wbArgs)
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testDataSourceAlertConfig(args...),
+				Config: fmt.Sprintf("%s\n%s", emsCfg, ds),
 				Check: resource.ComposeTestCheckFunc(
-					testDataSourceAlertExists(data),
-					resource.TestCheckResourceAttr(data, "name", rsName),
-					resource.TestCheckResourceAttr(data, "email_channel.#", "1"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.%", "7"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.operator", "presence"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr(data, "email_channel.0.triggerlimit", "15"),
+					testDataSourceAlertExists("data.logdna_alert.remote"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.#", "2"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.%", "7"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.1.%", "7"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: fmt.Sprintf("%s\n%s", pdsCfg, ds),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists("data.logdna_alert.remote"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "name", "test"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.#", "2"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.1.%", "6"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: fmt.Sprintf("%s\n%s", slsCfg, ds),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists("data.logdna_alert.remote"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "name", "test"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.#", "2"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.1.%", "6"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: fmt.Sprintf("%s\n%s", wbsCfg, ds),
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists("data.logdna_alert.remote"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "name", "test"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.#", "2"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.%", "9"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.1.%", "9"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.#", "0"),
 				),
 			},
 		},
 	})
 }
 
-func TestDataSourceAlert_basicPagerDuty(t *testing.T) {
-	data := "data.logdna_alert.remote"
-	rsName := "test"
-
-	args := []string{rsName, pagerduty}
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testDataSourceAlertConfig(args...),
-				Check: resource.ComposeTestCheckFunc(
-					testDataSourceAlertExists(data),
-					resource.TestCheckResourceAttr(data, "name", rsName),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.#", "1"),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.%", "6"),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.operator", "presence"),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr(data, "pagerduty_channel.0.triggerlimit", "15"),
-				),
-			},
-		},
-	})
-}
-
-func TestDataSourceAlert_basicWebhook(t *testing.T) {
-	data := "data.logdna_alert.remote"
-	rsName := "test"
-
-	args := []string{rsName, webhook}
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testDataSourceAlertConfig(args...),
-				Check: resource.ComposeTestCheckFunc(
-					testDataSourceAlertExists(data),
-					resource.TestCheckResourceAttr(data, "name", rsName),
-					resource.TestCheckResourceAttr(data, "webhook_channel.#", "1"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.%", "9"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.headers.%", "2"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.headers.hello", "test3"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.headers.test", "test2"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert From {{ name }}\"\n  }\n}"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.method", "post"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.url", "https://yourwebhook/endpoint"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr(data, "webhook_channel.0.triggerlimit", "15"),
-				),
-			},
-		},
-	})
-}
-
-func TestDataSourceAlert_multipleChannels(t *testing.T) {
-	data := "data.logdna_alert.remote"
-	rsName := "test"
-
-	args := []string{rsName, "multiple"}
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testDataSourceAlertConfig(args...),
-				Check: resource.ComposeTestCheckFunc(
-					testDataSourceAlertExists(data),
-					resource.TestCheckResourceAttr(data, "name", rsName),
-				),
-			},
-		},
-	})
-}
-
-func testDataSourceAlertConfig(args ...string) string {
-	name := args[0]
-	integration := args[1]
-	isMultiple := false
-	if integration == "multiple" {
-		isMultiple = true
+func TestDataSourceAlert_MultipleChannels(t *testing.T) {
+	chArgs := map[string]map[string]string{
+		"email":     cloneDefaults(chnlDefaults["email"]),
+		"pagerduty": cloneDefaults(chnlDefaults["pagerduty"]),
+		"slack":     cloneDefaults(chnlDefaults["slack"]),
+		"webhook":   cloneDefaults(chnlDefaults["webhook"]),
 	}
+	fmtCfg := fmt.Sprintf("%s\n%s", fmtTestConfigResource("alert", "test", nilLst, alertDefaults, chArgs), ds)
 
-	var sb strings.Builder
-	fmt.Fprintf(&sb, pcStr, serviceKey)
-
-	if isMultiple {
-		fmt.Fprintf(&sb, rsStrMultiple, name, email, pagerduty, webhook)
-	} else {
-		fmt.Fprintf(&sb, rsStr, name, integration)
-	}
-
-	sb.WriteString(dsStr)
-	return sb.String()
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmtCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testDataSourceAlertExists("data.logdna_alert.remote"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "name", "test"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.#", "1"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.emails.#", "1"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.emails.0", "test@logdna.com"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.operator", "absence"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.timezone", "Pacific/Samoa"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "email_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.#", "1"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.key", "Your PagerDuty API key goes here"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.operator", "presence"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "pagerduty_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.#", "1"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.operator", "absence"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.triggerinterval", "30m"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "slack_channel.0.url", "https://hooks.slack.com/services/identifier/secret"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.#", "1"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.%", "9"),
+					// The JSON will have newlines per our API which uses JSON.stringify(obj, null, 2) as the value
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert from {{ name }}\"\n  }\n}"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.headers.%", "2"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.headers.hello", "test3"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.headers.test", "test2"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.method", "post"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.operator", "presence"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("data.logdna_alert.remote", "webhook_channel.0.url", "https://yourwebhook/endpoint"),
+				),
+			},
+		},
+	})
 }
 
 func testDataSourceAlertExists(name string) resource.TestCheckFunc {

--- a/logdna/provider_test.go
+++ b/logdna/provider_test.go
@@ -27,11 +27,3 @@ func TestProvider(t *testing.T) {
 func TestProvider_impl(t *testing.T) {
 	var _ *schema.Provider = Provider()
 }
-
-// testAccPreCheck validates the necessary test API keys exist
-// in the testing environment
-func testAccPreCheck(t *testing.T) {
-	if serviceKey == "" {
-		t.Fatal("'SERVICE_KEY' environment variable must be set for acceptance tests")
-	}
-}

--- a/logdna/request_types.go
+++ b/logdna/request_types.go
@@ -104,6 +104,15 @@ func aggregateAllChannelsFromSchema(
 	allChannelEntries = append(
 		allChannelEntries,
 		*iterateIntegrationType(
+			d.Get("slack_channel").([]interface{}),
+			SLACK,
+			diags,
+		)...,
+	)
+
+	allChannelEntries = append(
+		allChannelEntries,
+		*iterateIntegrationType(
 			d.Get("webhook_channel").([]interface{}),
 			WEBHOOK,
 			diags,
@@ -133,6 +142,8 @@ func iterateIntegrationType(
 			prepared = emailChannelRequest(e)
 		case PAGERDUTY:
 			prepared = pagerDutyChannelRequest(e)
+		case SLACK:
+			prepared = slackChannelRequest(e)
 		case WEBHOOK:
 			prepared = webHookChannelRequest(e, diags)
 		default:
@@ -179,6 +190,20 @@ func pagerDutyChannelRequest(s map[string]interface{}) channelRequest {
 		Terminal:        s["terminal"].(string),
 		TriggerInterval: s["triggerinterval"].(string),
 		TriggerLimit:    s["triggerlimit"].(int),
+	}
+
+	return c
+}
+
+func slackChannelRequest(s map[string]interface{}) channelRequest {
+	c := channelRequest{
+		Immediate:       s["immediate"].(string),
+		Integration:     SLACK,
+		Operator:        s["operator"].(string),
+		Terminal:        s["terminal"].(string),
+		TriggerInterval: s["triggerinterval"].(string),
+		TriggerLimit:    s["triggerlimit"].(int),
+		URL:             s["url"].(string),
 	}
 
 	return c

--- a/logdna/resource_alert.go
+++ b/logdna/resource_alert.go
@@ -255,6 +255,48 @@ func resourceAlert() *schema.Resource {
 					},
 				},
 			},
+			"slack_channel": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"immediate": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "false",
+						},
+						"operator": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "presence",
+						},
+						"terminal": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "false",
+						},
+						"triggerinterval": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"triggerlimit": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								v := val.(int)
+								if v < 1 || v > 100000 {
+									errs = append(errs, fmt.Errorf("%q must be between 1 and 100,000 inclusive, got: %d", key, v))
+								}
+								return
+							},
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"webhook_channel": {
 				Type:     schema.TypeList,
 				Optional: true,

--- a/logdna/resource_alert_test.go
+++ b/logdna/resource_alert_test.go
@@ -9,293 +9,337 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAlert_checkEnvServiceKey(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testAccPreCheck(t) },
-	})
-}
+var alertDefaults = cloneDefaults(rsDefaults["alert"])
 
-func TestAlert_expectInvalidJSONError(t *testing.T) {
+func TestAlert_ErrorProviderUrl(t *testing.T) {
+	pcArgs := []string{serviceKey, "https://api.logdna.co"}
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
-		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config:      testAlertConfigMultipleChannelsInvalidJSON(),
-				ExpectError: regexp.MustCompile("Error: bodytemplate is not a valid JSON string"),
+				Config:      fmtTestConfigResource("alert", "new", pcArgs, alertDefaults, nilOpt),
+				ExpectError: regexp.MustCompile("Error: error during HTTP request: Post \"https://api.logdna.co/v1/config/presetalert\": dial tcp: lookup api.logdna.co"),
 			},
 		},
 	})
 }
 
-func TestAlert_expectTriggerIntervalError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertConfigTriggerIntervalError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.triggerinterval\\" must be one of \[15m, 30m, 1h, 6h, 12h, 24h\]"`),
-			},
-		},
-	})
-}
+func TestAlert_ErrorResourceName(t *testing.T) {
+	args := cloneDefaults(chnlDefaults["alert"])
+	args["name"] = ""
 
-func TestAlert_expectImmediateError(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAlertConfigImmediateError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.immediate\\" must be a boolean"`),
-			},
-		},
-	})
-}
-
-func TestAlert_expectURLError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertConfigURLError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.url\\" must be a valid uri"`),
-			},
-		},
-	})
-}
-
-func TestAlert_expectMethodError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertConfigMethodError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\].method\\" must be one of \[post, put, patch, get, delete\]"`),
-			},
-		},
-	})
-}
-
-func TestAlert_expectServiceKeyError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertConfigServiceKeyError(),
-				ExpectError: regexp.MustCompile("The argument \"servicekey\" is required, but no definition was found."),
-			},
-		},
-	})
-}
-
-func TestAlert_expectNameError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertNameError(),
+				Config:      fmtTestConfigResource("alert", "new", nilLst, args, nilOpt),
 				ExpectError: regexp.MustCompile("The argument \"name\" is required, but no definition was found."),
 			},
 		},
 	})
 }
 
-func TestAlert_expectEmailTriggerLimitError(t *testing.T) {
+func TestAlert_ErrorsChannel(t *testing.T) {
+	imArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	imArgs["email"]["immediate"] = `"not a bool"`
+	immdte := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, imArgs)
+
+	opArgs := map[string]map[string]string{"pagerduty": cloneDefaults(chnlDefaults["pagerduty"])}
+	opArgs["pagerduty"]["operator"] = `1000`
+	opratr := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, opArgs)
+
+	trArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	trArgs["webhook"]["terminal"] = `"invalid"`
+	trmnal := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, trArgs)
+
+	tiArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	tiArgs["email"]["triggerinterval"] = `18`
+	tintvl := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, tiArgs)
+
+	tlArgs := map[string]map[string]string{"slack": cloneDefaults(chnlDefaults["slack"])}
+	tlArgs["slack"]["triggerlimit"] = `0`
+	tlimit := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, tlArgs)
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAlertConfigEmailTriggerLimitError(),
-				ExpectError: regexp.MustCompile("Error: \"email_channel.0.triggerlimit\" must be between 1 and 100,000 inclusive, got: 0"),
+				Config:      immdte,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].immediate\\" must be a boolean"`),
+			},
+			{
+				Config:      opratr,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].operator\\" must be one of \[presence, absence\]"`),
+			},
+			{
+				Config:      trmnal,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].terminal\\" must be a boolean"`),
+			},
+			{
+				Config:      tintvl,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].triggerinterval\\" must be one of \[15m, 30m, 1h, 6h, 12h, 24h\]"`),
+			},
+			{
+				Config:      tlimit,
+				ExpectError: regexp.MustCompile(`Error: ".*channel.0.triggerlimit" must be between 1 and 100,000 inclusive`),
 			},
 		},
 	})
 }
 
-func TestAlert_expectPagerDutyTriggerLimitError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertConfigPagerDutyTriggerLimitError(),
-				ExpectError: regexp.MustCompile("Error: \"pagerduty_channel.0.triggerlimit\" must be between 1 and 100,000 inclusive, got: 0"),
-			},
-		},
-	})
-}
+func TestAlert_ErrorsEmailChannel(t *testing.T) {
+	msArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	msArgs["email"]["emails"] = ""
+	misngE := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, msArgs)
 
-func TestAlert_expectWebhookTriggerLimitError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAlertConfigWebhookTriggerLimitError(),
-				ExpectError: regexp.MustCompile("Error: \"webhook_channel.0.triggerlimit\" must be between 1 and 100,000 inclusive, got: 0"),
-			},
-		},
-	})
-}
+	inArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	inArgs["email"]["emails"] = `"not an array of strings"`
+	invldE := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, inArgs)
 
-func TestAlert_expectMissingEmails(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAlertConfigMissingEmails(),
+				Config:      misngE,
 				ExpectError: regexp.MustCompile("The argument \"emails\" is required, but no definition was found."),
 			},
+			{
+				Config:      invldE,
+				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"emails\": list of string required"),
+			},
 		},
 	})
 }
 
-func TestAlert_expectMissingKey(t *testing.T) {
+func TestAlert_ErrorsPagerDutyChannel(t *testing.T) {
+	chArgs := map[string]map[string]string{"pagerduty": cloneDefaults(chnlDefaults["pagerduty"])}
+	chArgs["pagerduty"]["key"] = ""
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAlertConfigMissingKey(),
+				Config:      fmtTestConfigResource("alert", "new", nilLst, alertDefaults, chArgs),
 				ExpectError: regexp.MustCompile("The argument \"key\" is required, but no definition was found."),
 			},
 		},
 	})
 }
 
-func TestAlert_expectMissingURL(t *testing.T) {
+func TestAlert_ErrorsSlackChannel(t *testing.T) {
+	ulInvd := map[string]map[string]string{"slack": cloneDefaults(chnlDefaults["slack"])}
+	ulInvd["slack"]["url"] = `"this is not a valid url"`
+	ulCfgE := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, ulInvd)
+
+	ulMsng := map[string]map[string]string{"slack": cloneDefaults(chnlDefaults["slack"])}
+	ulMsng["slack"]["url"] = ""
+	ulCfgM := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, ulMsng)
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAlertConfigMissingURL(),
+				Config:      ulCfgE,
+				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.url\\" must be a valid uri"`),
+			},
+			{
+				Config:      ulCfgM,
 				ExpectError: regexp.MustCompile("The argument \"url\" is required, but no definition was found."),
 			},
 		},
 	})
 }
-func TestAlertBasic(t *testing.T) {
-	name := "test"
+
+func TestAlert_ErrorsWebhookChannel(t *testing.T) {
+	btArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	btArgs["webhook"]["bodytemplate"] = `"{\"test\": }"`
+	btCfgE := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, btArgs)
+
+	mdArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	mdArgs["webhook"]["method"] = `"false"`
+	mdCfgE := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, mdArgs)
+
+	ulInvd := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	ulInvd["webhook"]["url"] = `"this is not a valid url"`
+	ulCfgE := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, ulInvd)
+
+	ulMsng := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	ulMsng["webhook"]["url"] = ""
+	ulCfgM := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, ulMsng)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAlertConfigBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAlertExists("logdna_alert.new"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "1"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.%", "7"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.operator", "presence"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
-				),
-			},
-			{
-				ResourceName:      "logdna_alert.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAlertBasicUpdate(t *testing.T) {
-	name := "test"
-	name2 := "test2"
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAlertConfigBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAlertExists("logdna_alert.new"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "name", name),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "1"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.%", "7"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.operator", "presence"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
-				),
-			},
-			{
-				Config: testAlertConfigBasic(name2),
-				Check: resource.ComposeTestCheckFunc(
-					testAlertExists("logdna_alert.new"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "name", name2),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "1"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.%", "7"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.operator", "presence"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
-				),
-			},
-			{
-				ResourceName:      "logdna_alert.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAlertJSONUpdateError(t *testing.T) {
-	name := "test"
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAlertConfigBasic(name),
-				Check: resource.ComposeTestCheckFunc(
-					testAlertExists("logdna_alert.new"),
-				),
-			},
-			{
-				ResourceName:      "logdna_alert.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config:      testAlertConfigMultipleChannelsInvalidJSON(),
+				Config:      btCfgE,
 				ExpectError: regexp.MustCompile("Error: bodytemplate is not a valid JSON string"),
 			},
+			{
+				Config:      mdCfgE,
+				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\].method\\" must be one of \[post, put, patch, get, delete\]"`),
+			},
+			{
+				Config:      ulCfgE,
+				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.url\\" must be a valid uri"`),
+			},
+			{
+				Config:      ulCfgM,
+				ExpectError: regexp.MustCompile("The argument \"url\" is required, but no definition was found."),
+			},
 		},
 	})
 }
 
-func TestAlertMultipleChannels(t *testing.T) {
-	name := "test"
+func TestAlert_Basic(t *testing.T) {
+	chArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	iniCfg := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, chArgs)
+
+	rsArgs := cloneDefaults(rsDefaults["alert"])
+	rsArgs["name"] = `"test2"`
+	updCfg := fmtTestConfigResource("alert", "new", nilLst, rsArgs, chArgs)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAlertConfigMultipleChannels(name),
+				Config: iniCfg,
 				Check: resource.ComposeTestCheckFunc(
 					testAlertExists("logdna_alert.new"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "1"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.%", "7"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.#", "1"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.0", "test@logdna.com"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.operator", "absence"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.timezone", "Pacific/Samoa"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: updCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAlertExists("logdna_alert.new"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test2"),
+				),
+			},
+			{
+				ResourceName:      "logdna_alert.new",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAlert_BulkChannels(t *testing.T) {
+	emArgs := map[string]map[string]string{
+		"email":  cloneDefaults(chnlDefaults["email"]),
+		"email1": cloneDefaults(chnlDefaults["email"]),
+	}
+	emsCfg := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, emArgs)
+
+	pdArgs := map[string]map[string]string{
+		"pagerduty":  cloneDefaults(chnlDefaults["pagerduty"]),
+		"pagerduty1": cloneDefaults(chnlDefaults["pagerduty"]),
+	}
+	pdsCfg := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, pdArgs)
+
+	slArgs := map[string]map[string]string{
+		"slack":  cloneDefaults(chnlDefaults["slack"]),
+		"slack1": cloneDefaults(chnlDefaults["slack"]),
+	}
+	slsCfg := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, slArgs)
+
+	wbArgs := map[string]map[string]string{
+		"webhook":  cloneDefaults(chnlDefaults["webhook"]),
+		"webhook1": cloneDefaults(chnlDefaults["webhook"]),
+	}
+	wbsCfg := fmtTestConfigResource("alert", "new", nilLst, alertDefaults, wbArgs)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: emsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAlertExists("logdna_alert.new"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.%", "7"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.1.%", "7"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: pdsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAlertExists("logdna_alert.new"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.1.%", "6"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: slsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAlertExists("logdna_alert.new"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.1.%", "6"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: wbsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAlertExists("logdna_alert.new"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.%", "9"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.1.%", "9"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAlert_MultipleChannels(t *testing.T) {
+	chArgs := map[string]map[string]string{
+		"email":     cloneDefaults(chnlDefaults["email"]),
+		"pagerduty": cloneDefaults(chnlDefaults["pagerduty"]),
+		"slack":     cloneDefaults(chnlDefaults["slack"]),
+		"webhook":   cloneDefaults(chnlDefaults["webhook"]),
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmtTestConfigResource("alert", "new", nilLst, alertDefaults, chArgs),
+				Check: resource.ComposeTestCheckFunc(
+					testAlertExists("logdna_alert.new"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.#", "1"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.#", "1"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.emails.0", "test@logdna.com"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.immediate", "false"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.operator", "absence"),
@@ -305,13 +349,34 @@ func TestAlertMultipleChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_alert.new", "email_channel.0.triggerlimit", "15"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.#", "1"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.%", "6"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.immediate", "true"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.immediate", "false"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.key", "Your PagerDuty API key goes here"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.operator", "presence"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.terminal", "true"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.triggerinterval", "15m"),
 					resource.TestCheckResourceAttr("logdna_alert.new", "pagerduty_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert From {{ name }}\"\n  }\n}"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.#", "1"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.operator", "absence"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.triggerinterval", "30m"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "slack_channel.0.url", "https://hooks.slack.com/services/identifier/secret"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.#", "1"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.%", "9"),
+					// The JSON will have newlines per our API which uses JSON.stringify(obj, null, 2) as the value
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert from {{ name }}\"\n  }\n}"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.headers.%", "2"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.headers.hello", "test3"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.headers.test", "test2"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.method", "post"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.operator", "presence"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.triggerinterval", "15m"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("logdna_alert.new", "webhook_channel.0.url", "https://yourwebhook/endpoint"),
 				),
 			},
 			{
@@ -319,327 +384,8 @@ func TestAlertMultipleChannels(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config:      testAlertConfigMultipleChannelsInvalidJSON(),
-				ExpectError: regexp.MustCompile("Error: bodytemplate is not a valid JSON string"),
-			},
 		},
 	})
-}
-
-func testAlertConfigMultipleChannelsInvalidJSON() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_alert" "new" {
-		name = "test"
-		email_channel {
-		  emails          = ["test@logdna.com"]
-		  immediate       = "false"
-		  operator        = "absence"
-		  terminal        = "true"
-		  timezone        = "Pacific/Samoa"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-
-		pagerduty_channel {
-		  immediate       = "false"
-		  key             = "Your PagerDuty API key goes here"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  bodytemplate = "{\"test\": }"
-		  immediate       = "false"
-		  method          = "post"
-		  url             = "https://yourwebhook/endpoint"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey)
-}
-
-func testAlertConfigTriggerIntervalError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-      }
-
-      resource "logdna_alert" "new" {
-        name = "test"
-        email_channel {
-          emails          = ["test@logdna.com"]
-          immediate       = "false"
-          operator        = "absence"
-          terminal        = "true"
-          timezone        = "Pacific/Samoa"
-          triggerinterval = "17m"
-          triggerlimit    = 15
-        }
-      }`, serviceKey)
-}
-
-func testAlertConfigImmediateError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-      }
-
-      resource "logdna_alert" "new" {
-        name = "test"
-        email_channel {
-          emails          = ["test@logdna.com"]
-          immediate       = "no"
-          operator        = "absence"
-          terminal        = "true"
-          timezone        = "Pacific/Samoa"
-          triggerinterval = "15m"
-          triggerlimit    = 15
-        }
-      }`, serviceKey)
-}
-
-func testAlertConfigURLError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_alert" "new" {
-		name = "test"
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  immediate       = "false"
-		  method          = "post"
-		  url             = "this is not a valid url"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey)
-}
-
-func testAlertConfigMethodError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_alert" "new" {
-		name = "test"
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  immediate       = "false"
-		  method          = "false"
-		  url             = "http://yourwebhook/test"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey)
-}
-
-func testAlertConfigServiceKeyError() string {
-	return `provider "logdna" {
-	  }
-
-	resource "logdna_alert" "new" {
-		name = "test"
-	}`
-}
-
-func testAlertNameError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_alert" "new" {
-	}`, serviceKey)
-}
-
-func testAlertConfigEmailTriggerLimitError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	resource "logdna_alert" "new" {
-		name = "test"
-		email_channel {
-			emails          = ["test@logdna.com"]
-			immediate       = "false"
-			operator        = "presence"
-			triggerlimit    = 0
-			triggerinterval = "15m"
-			terminal        = "true"
-			timezone        = "Pacific/Samoa"
-		}
-	}`, serviceKey)
-}
-
-func testAlertConfigPagerDutyTriggerLimitError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	resource "logdna_alert" "new" {
-		name = "test"
-		pagerduty_channel {
-			immediate       = "false"
-			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 0
-		}
-	}`, serviceKey)
-}
-
-func testAlertConfigWebhookTriggerLimitError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	resource "logdna_alert" "new" {
-		name = "test"
-		webhook_channel {
-			headers = {
-			  hello = "test3"
-			  test  = "test2"
-			}
-			immediate       = "false"
-			method          = "post"
-			url             = "https://yourwebhook/endpoint"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 0
-		}
-	}`, serviceKey)
-}
-
-func testAlertConfigMissingEmails() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_alert" "new" {
-		name     = "test"
-		email_channel {
-			immediate       = "false"
-			operator        = "absence"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-			timezone        = "Pacific/Samoa"
-		}
-	}`, serviceKey)
-}
-
-func testAlertConfigMissingKey() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_alert" "new" {
-		name     = "test"
-		pagerduty_channel {
-			immediate       = "false"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-		}
-	}`, serviceKey)
-}
-
-func testAlertConfigMissingURL() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_alert" "new" {
-		name     = "test"
-		webhook_channel {
-			triggerlimit    = 15
-		}
-	}`, serviceKey)
-}
-
-func testAlertConfigBasic(name string) string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	resource "logdna_alert" "new" {
-		name = "%s"
-		email_channel {
-			emails          = ["test@logdna.com"]
-			immediate       = "false"
-			operator        = "presence"
-			triggerlimit    = 15
-			triggerinterval = "15m"
-			terminal        = "true"
-			timezone        = "Pacific/Samoa"
-		}
-	}`, serviceKey, name)
-}
-
-func testAlertConfigMultipleChannels(name string) string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	resource "logdna_alert" "new" {
-		name = "%s"
-		email_channel {
-			emails          = ["test@logdna.com"]
-			immediate       = "false"
-			operator        = "absence"
-			terminal        = "true"
-			timezone        = "Pacific/Samoa"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-		}
-		pagerduty_channel {
-			immediate       = "true"
-			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-		}
-		webhook_channel {
-			headers = {
-				hello = "test3"
-				test  = "test2"
-			}
-			bodytemplate = jsonencode({
-			fields = {
-				description = "{{ matches }} matches found for {{ name }}"
-				issuetype = {
-					name = "Bug"
-				}
-				project = {
-					key = "test"
-				},
-				summary = "Alert From {{ name }}"
-			 }
-			})
-			immediate       = "false"
-			method          = "post"
-			url             = "https://yourwebhook/endpoint"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-		}
-	}`, serviceKey, name)
 }
 
 func testAlertExists(n string) resource.TestCheckFunc {

--- a/logdna/resource_view.go
+++ b/logdna/resource_view.go
@@ -16,6 +16,7 @@ import (
 const (
 	EMAIL     = "email"
 	PAGERDUTY = "pagerduty"
+	SLACK     = "slack"
 	WEBHOOK   = "webhook"
 )
 
@@ -239,6 +240,7 @@ func resourceView() *schema.Resource {
 						"operator": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "presence",
 						},
 						"terminal": {
 							Type:     schema.TypeString,
@@ -305,6 +307,48 @@ func resourceView() *schema.Resource {
 								}
 								return
 							},
+						},
+					},
+				},
+			},
+			"slack_channel": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"immediate": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "false",
+						},
+						"operator": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "presence",
+						},
+						"terminal": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "false",
+						},
+						"triggerinterval": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"triggerlimit": {
+							Type:     schema.TypeInt,
+							Required: true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								v := val.(int)
+								if v < 1 || v > 100000 {
+									errs = append(errs, fmt.Errorf("%q must be between 1 and 100,000 inclusive, got: %d", key, v))
+								}
+								return
+							},
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
 						},
 					},
 				},

--- a/logdna/resource_view_test.go
+++ b/logdna/resource_view_test.go
@@ -9,385 +9,264 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestView_expectInvalidURLError(t *testing.T) {
+const ctgies = `["DEMOCATEGORY1", "DemoCategory2"]`
+
+var viewDefaults = cloneDefaults(rsDefaults["view"])
+
+func TestView_ErrorProviderUrl(t *testing.T) {
+	pcArgs := []string{serviceKey, "https://api.logdna.co"}
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testViewInvalidURL(),
-				ExpectError: regexp.MustCompile("Error: error during HTTP request: Post \"http://api.logdna.co/v1/config/view\": dial tcp: lookup api.logdna.co"),
+				Config:      fmtTestConfigResource("view", "new", pcArgs, viewDefaults, nilOpt),
+				ExpectError: regexp.MustCompile("Error: error during HTTP request: Post \"https://api.logdna.co/v1/config/view\": dial tcp: lookup api.logdna.co"),
 			},
 		},
 	})
 }
 
-func TestView_expectInvalidJSONError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigMultipleChannelsInvalidJSON(),
-				ExpectError: regexp.MustCompile("Error: bodytemplate is not a valid JSON string"),
-			},
-		},
-	})
-}
+func TestView_ErrorsResourceFields(t *testing.T) {
+	nme := cloneDefaults(rsDefaults["view"])
+	nme["name"] = ""
+	nmeCfg := fmtTestConfigResource("view", "new", nilLst, nme, nilOpt)
 
-func TestView_expectTriggerIntervalError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigTriggerIntervalError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.triggerinterval\\" must be one of \[15m, 30m, 1h, 6h, 12h, 24h\]"`),
-			},
-		},
-	})
-}
+	app := cloneDefaults(rsDefaults["view"])
+	app["apps"] = `"invalid apps value"`
+	appCfg := fmtTestConfigResource("view", "new", nilLst, app, nilOpt)
 
-func TestView_expectImmediateError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigImmediateError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.immediate\\" must be a boolean"`),
-			},
-		},
-	})
-}
+	ctg := cloneDefaults(rsDefaults["view"])
+	ctg["categories"] = `"invalid categories value"`
+	ctgCfg := fmtTestConfigResource("view", "new", nilLst, ctg, nilOpt)
 
-func TestView_expectURLError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigURLError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.url\\" must be a valid uri"`),
-			},
-		},
-	})
-}
+	hst := cloneDefaults(rsDefaults["view"])
+	hst["hosts"] = `"invalid hosts value"`
+	hstCfg := fmtTestConfigResource("view", "new", nilLst, hst, nilOpt)
 
-func TestView_expectMethodError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigMethodError(),
-				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\].method\\" must be one of \[post, put, patch, get, delete\]"`),
-			},
-		},
-	})
-}
+	lvl := cloneDefaults(rsDefaults["view"])
+	lvl["levels"] = `"invalid levels value"`
+	lvlCfg := fmtTestConfigResource("view", "new", nilLst, lvl, nilOpt)
 
-func TestView_expectServiceKeyError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigServiceKeyError(),
-				ExpectError: regexp.MustCompile("The argument \"servicekey\" is required, but no definition was found."),
-			},
-		},
-	})
-}
+	tgs := cloneDefaults(rsDefaults["view"])
+	tgs["tags"] = `"invalid tags value"`
+	tgsCfg := fmtTestConfigResource("view", "new", nilLst, tgs, nilOpt)
 
-func TestView_expectNameError(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigNameError(),
+				Config:      nmeCfg,
 				ExpectError: regexp.MustCompile("The argument \"name\" is required, but no definition was found."),
 			},
-		},
-	})
-}
-
-func TestView_expectAppsError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigAppsError(),
+				Config:      appCfg,
 				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"apps\": list of string required."),
 			},
-		},
-	})
-}
-func TestView_expectCategoriesError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigCategoriesError(),
+				Config:      ctgCfg,
 				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"categories\": list of string required."),
 			},
-		},
-	})
-}
-
-func TestView_expectHostsError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigHostsError(),
+				Config:      hstCfg,
 				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"hosts\": list of string required."),
 			},
-		},
-	})
-}
-
-func TestView_expectLevelsError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigLevelsError(),
+				Config:      lvlCfg,
 				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"levels\": list of string required."),
 			},
-		},
-	})
-}
-
-func TestView_expectTagsError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigTagsError(),
+				Config:      tgsCfg,
 				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"tags\": list of string required."),
 			},
 		},
 	})
 }
 
-func TestView_expectEmailTriggerLimitError(t *testing.T) {
+func TestView_ErrorsChannel(t *testing.T) {
+	imArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	imArgs["email"]["immediate"] = `"not a bool"`
+	immdte := fmtTestConfigResource("view", "new", nilLst, viewDefaults, imArgs)
+
+	opArgs := map[string]map[string]string{"pagerduty": cloneDefaults(chnlDefaults["pagerduty"])}
+	opArgs["pagerduty"]["operator"] = `1000`
+	opratr := fmtTestConfigResource("view", "new", nilLst, viewDefaults, opArgs)
+
+	trArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	trArgs["webhook"]["terminal"] = `"invalid"`
+	trmnal := fmtTestConfigResource("view", "new", nilLst, viewDefaults, trArgs)
+
+	tiArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	tiArgs["email"]["triggerinterval"] = `18`
+	tintvl := fmtTestConfigResource("view", "new", nilLst, viewDefaults, tiArgs)
+
+	tlArgs := map[string]map[string]string{"slack": cloneDefaults(chnlDefaults["slack"])}
+	tlArgs["slack"]["triggerlimit"] = `0`
+	tlimit := fmtTestConfigResource("view", "new", nilLst, viewDefaults, tlArgs)
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigEmailTriggerLimitError(),
-				ExpectError: regexp.MustCompile("Error: \"email_channel.0.triggerlimit\" must be between 1 and 100,000 inclusive, got: 0"),
+				Config:      immdte,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].immediate\\" must be a boolean"`),
+			},
+			{
+				Config:      opratr,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].operator\\" must be one of \[presence, absence\]"`),
+			},
+			{
+				Config:      trmnal,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].terminal\\" must be a boolean"`),
+			},
+			{
+				Config:      tintvl,
+				ExpectError: regexp.MustCompile(`"\\"channels\[0\].triggerinterval\\" must be one of \[15m, 30m, 1h, 6h, 12h, 24h\]"`),
+			},
+			{
+				Config:      tlimit,
+				ExpectError: regexp.MustCompile(`Error: ".*channel.0.triggerlimit" must be between 1 and 100,000 inclusive`),
 			},
 		},
 	})
 }
 
-func TestView_expectPagerDutyTriggerLimitError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigPagerDutyTriggerLimitError(),
-				ExpectError: regexp.MustCompile("Error: \"pagerduty_channel.0.triggerlimit\" must be between 1 and 100,000 inclusive, got: 0"),
-			},
-		},
-	})
-}
+func TestView_ErrorsEmailChannel(t *testing.T) {
+	msArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	msArgs["email"]["emails"] = ""
+	misngE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, msArgs)
 
-func TestView_expectWebhookTriggerLimitError(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config:      testViewConfigWebhookTriggerLimitError(),
-				ExpectError: regexp.MustCompile("Error: \"webhook_channel.0.triggerlimit\" must be between 1 and 100,000 inclusive, got: 0"),
-			},
-		},
-	})
-}
+	inArgs := map[string]map[string]string{"email": cloneDefaults(chnlDefaults["email"])}
+	inArgs["email"]["emails"] = `"not an array of strings"`
+	invldE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, inArgs)
 
-func TestView_expectMissingEmails(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigMissingEmails(),
+				Config:      misngE,
 				ExpectError: regexp.MustCompile("The argument \"emails\" is required, but no definition was found."),
 			},
+			{
+				Config:      invldE,
+				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"emails\": list of string required"),
+			},
 		},
 	})
 }
 
-func TestView_expectMissingKey(t *testing.T) {
+func TestView_ErrorsPagerDutyChannel(t *testing.T) {
+	chArgs := map[string]map[string]string{"pagerduty": cloneDefaults(chnlDefaults["pagerduty"])}
+	chArgs["pagerduty"]["key"] = ""
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigMissingKey(),
+				Config:      fmtTestConfigResource("view", "new", nilLst, viewDefaults, chArgs),
 				ExpectError: regexp.MustCompile("The argument \"key\" is required, but no definition was found."),
 			},
 		},
 	})
 }
 
-func TestView_expectMissingURL(t *testing.T) {
+func TestView_ErrorsSlackChannel(t *testing.T) {
+	ulInvd := map[string]map[string]string{"slack": cloneDefaults(chnlDefaults["slack"])}
+	ulInvd["slack"]["url"] = `"this is not a valid url"`
+	ulCfgE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, ulInvd)
+
+	ulMsng := map[string]map[string]string{"slack": cloneDefaults(chnlDefaults["slack"])}
+	ulMsng["slack"]["url"] = ""
+	ulCfgM := fmtTestConfigResource("view", "new", nilLst, viewDefaults, ulMsng)
+
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:      testViewConfigMissingURL(),
+				Config:      ulCfgE,
+				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.url\\" must be a valid uri"`),
+			},
+			{
+				Config:      ulCfgM,
 				ExpectError: regexp.MustCompile("The argument \"url\" is required, but no definition was found."),
 			},
 		},
 	})
 }
-func TestViewBasic(t *testing.T) {
-	name := "test"
-	query := "test"
+
+func TestView_ErrorsWebhookChannel(t *testing.T) {
+	btArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	btArgs["webhook"]["bodytemplate"] = `"{\"test\": }"`
+	btCfgE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, btArgs)
+
+	hdArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	hdArgs["webhook"]["headers"] = `["headers", "invalid", "array"]`
+	hdCfgE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, hdArgs)
+
+	mdArgs := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	mdArgs["webhook"]["method"] = `"false"`
+	mdCfgE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, mdArgs)
+
+	ulInvd := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	ulInvd["webhook"]["url"] = `"this is not a valid url"`
+	ulCfgE := fmtTestConfigResource("view", "new", nilLst, viewDefaults, ulInvd)
+
+	ulMsng := map[string]map[string]string{"webhook": cloneDefaults(chnlDefaults["webhook"])}
+	ulMsng["webhook"]["url"] = ""
+	ulCfgM := fmtTestConfigResource("view", "new", nilLst, viewDefaults, ulMsng)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testViewConfigBasic(name, query),
-				Check: resource.ComposeTestCheckFunc(
-					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query),
-				),
-			},
-			{
-				ResourceName:      "logdna_view.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestViewBasicUpdate(t *testing.T) {
-	name := "test"
-	query := "test"
-	name2 := "test2"
-	query2 := "test2"
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testViewConfigBasic(name, query),
-				Check: resource.ComposeTestCheckFunc(
-					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query),
-				),
-			},
-			{
-				Config: testViewConfigBasic(name2, query2),
-				Check: resource.ComposeTestCheckFunc(
-					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name2),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query2),
-				),
-			},
-			{
-				ResourceName:      "logdna_view.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestViewJSONUpdateError(t *testing.T) {
-	name := "test"
-	query := "test"
-	app1 := "app1"
-	app2 := "app2"
-	levels1 := "fatal"
-	levels2 := "critical"
-	host1 := "host1"
-	host2 := "host2"
-	category1 := "DEMOCATEGORY1"
-	category2 := "DemoCategory2"
-	tags1 := "host1"
-	tags2 := "host2"
-
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testViewConfigMultipleChannels(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2),
-				Check: resource.ComposeTestCheckFunc(
-					testViewExists("logdna_view.new"),
-				),
-			},
-			{
-				ResourceName:      "logdna_view.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config:      testViewConfigMultipleChannelsInvalidJSON(),
+				Config:      btCfgE,
 				ExpectError: regexp.MustCompile("Error: bodytemplate is not a valid JSON string"),
 			},
+			{
+				Config:      hdCfgE,
+				ExpectError: regexp.MustCompile("Inappropriate value for attribute \"headers\": map of string required"),
+			},
+			{
+				Config:      mdCfgE,
+				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\].method\\" must be one of \[post, put, patch, get, delete\]"`),
+			},
+			{
+				Config:      ulCfgE,
+				ExpectError: regexp.MustCompile(`"message":"\\"channels\[0\]\.url\\" must be a valid uri"`),
+			},
+			{
+				Config:      ulCfgM,
+				ExpectError: regexp.MustCompile("The argument \"url\" is required, but no definition was found."),
+			},
 		},
 	})
 }
 
-func TestViewBulkEmails(t *testing.T) {
-	name := "test"
-	query := "test"
-	app1 := "app1"
-	app2 := "app2"
-	levels1 := "fatal"
-	levels2 := "critical"
-	host1 := "host1"
-	host2 := "host2"
-	category1 := "DEMOCATEGORY1"
-	category2 := "DemoCategory2"
-	tags1 := "host1"
-	tags2 := "host2"
+func TestView_Basic(t *testing.T) {
+	iniCfg := fmtTestConfigResource("view", "new", nilLst, viewDefaults, nilOpt)
+
+	rsArgs := cloneDefaults(rsDefaults["view"])
+	rsArgs["name"] = `"test2"`
+	rsArgs["query"] = `"test2"`
+	updCfg := fmtTestConfigResource("view", "new", nilLst, rsArgs, nilOpt)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testViewConfigBulkEmails(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2),
+				Config: iniCfg,
 				Check: resource.ComposeTestCheckFunc(
 					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app1),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app2),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.operator", "absence"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.%", "7"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.operator", "absence"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host1),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.1", host2),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host1),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.0", levels1),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", levels2),
-					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "0"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.0", tags1),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", tags2),
-					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channels.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test"),
+				),
+			},
+			{
+				Config: updCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testViewExists("logdna_view.new"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test2"),
 				),
 			},
 			{
@@ -399,163 +278,145 @@ func TestViewBulkEmails(t *testing.T) {
 	})
 }
 
-func TestViewBulkEmailsUpdate(t *testing.T) {
-	name := "test"
-	query := "test"
-	app1 := "app1"
-	app2 := "app2"
-	levels1 := "fatal"
-	levels2 := "critical"
-	host1 := "host1"
-	host2 := "host2"
-	category1 := "DEMOCATEGORY1"
-	category2 := "DemoCategory2"
-	tags1 := "host1"
-	tags2 := "host2"
+func TestView_BulkChannels(t *testing.T) {
+	emArgs := map[string]map[string]string{
+		"email":  cloneDefaults(chnlDefaults["email"]),
+		"email1": cloneDefaults(chnlDefaults["email"]),
+	}
+	emsCfg := fmtTestConfigResource("view", "new", nilLst, viewDefaults, emArgs)
 
-	name2 := "test2"
-	query2 := "query2"
-	app3 := "app3"
-	app4 := "app4"
-	levels3 := "error"
-	levels4 := "warning"
-	host3 := "host3"
-	host4 := "host4"
-	tags3 := "tags3"
-	tags4 := "tags4"
+	pdArgs := map[string]map[string]string{
+		"pagerduty":  cloneDefaults(chnlDefaults["pagerduty"]),
+		"pagerduty1": cloneDefaults(chnlDefaults["pagerduty"]),
+	}
+	pdsCfg := fmtTestConfigResource("view", "new", nilLst, viewDefaults, pdArgs)
 
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testViewConfigBulkEmails(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2),
-				Check: resource.ComposeTestCheckFunc(
-					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app1),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app2),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.operator", "absence"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.%", "7"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.operator", "absence"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host1),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.1", host2),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host1),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.0", levels1),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", levels2),
-					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "0"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.0", host1),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", host2),
-					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channels.#", "0"),
-				),
-			},
-			{
-				Config: testViewConfigBulkEmails(name2, query2, app3, app4, levels3, levels4, host3, host4, category1, category2, tags3, tags4),
-				Check: resource.ComposeTestCheckFunc(
-					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name2),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query2),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app3),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app4),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.operator", "absence"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.%", "7"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.emails.#", "1"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.emails.0", "test@logdna.com"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.immediate", "false"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.operator", "absence"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.terminal", "true"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.timezone", "Pacific/Samoa"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.triggerinterval", "15m"),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host3),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.1", host4),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host3),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.0", levels3),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", levels4),
-					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "0"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.0", tags3),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", tags4),
-					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channels.#", "0"),
-				),
-			},
-			{
-				ResourceName:      "logdna_view.new",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
+	slArgs := map[string]map[string]string{
+		"slack":  cloneDefaults(chnlDefaults["slack"]),
+		"slack1": cloneDefaults(chnlDefaults["slack"]),
+	}
+	slsCfg := fmtTestConfigResource("view", "new", nilLst, viewDefaults, slArgs)
 
-func TestViewMultipleChannels(t *testing.T) {
-	name := "test"
-	query := "test"
-	app1 := "app1"
-	app2 := "app2"
-	levels1 := "fatal"
-	levels2 := "critical"
-	host1 := "host1"
-	host2 := "host2"
-	category1 := "DemoCategory1"
-	category2 := "DemoCategory2"
-	tags1 := "host1"
-	tags2 := "host2"
+	wbArgs := map[string]map[string]string{
+		"webhook":  cloneDefaults(chnlDefaults["webhook"]),
+		"webhook1": cloneDefaults(chnlDefaults["webhook"]),
+	}
+	wbsCfg := fmtTestConfigResource("view", "new", nilLst, viewDefaults, wbArgs)
 
 	resource.Test(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testViewConfigMultipleChannels(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2),
+				Config: emsCfg,
 				Check: resource.ComposeTestCheckFunc(
 					testViewExists("logdna_view.new"),
-					resource.TestCheckResourceAttr("logdna_view.new", "name", name),
-					resource.TestCheckResourceAttr("logdna_view.new", "query", query),
-					resource.TestCheckResourceAttr("logdna_view.new", "%", "11"),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", app1),
-					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", app2),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", category1),
-					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", category2),
-					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "1"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.%", "7"),
+					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.1.%", "7"),
+					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: pdsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testViewExists("logdna_view.new"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.1.%", "6"),
+					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: slsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testViewExists("logdna_view.new"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.1.%", "6"),
+					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.#", "0"),
+				),
+			},
+			{
+				Config: wbsCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testViewExists("logdna_view.new"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.%", "9"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.1.%", "9"),
+					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "0"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestView_MultipleChannels(t *testing.T) {
+	chArgs := map[string]map[string]string{
+		"email":     cloneDefaults(chnlDefaults["email"]),
+		"pagerduty": cloneDefaults(chnlDefaults["pagerduty"]),
+		"slack":     cloneDefaults(chnlDefaults["slack"]),
+		"webhook":   cloneDefaults(chnlDefaults["webhook"]),
+	}
+
+	rsArgs := cloneDefaults(rsDefaults["view"])
+	rsArgs["apps"] = `["app1", "app2"]`
+	rsArgs["categories"] = ctgies
+	rsArgs["hosts"] = `["host1", "host2"]`
+	rsArgs["levels"] = `["fatal", "critical"]`
+	rsArgs["tags"] = `["tags1", "tags2"]`
+	iniCfg := fmtTestConfigResource("view", "new", nilLst, rsArgs, chArgs)
+
+	rsUptd := cloneDefaults(rsDefaults["view"])
+	rsUptd["apps"] = `["app3", "app4"]`
+	rsUptd["categories"] = ctgies
+	rsUptd["hosts"] = `["host3", "host4"]`
+	rsUptd["levels"] = `["error", "warning"]`
+	rsUptd["tags"] = `["tags3", "tags4"]`
+	rsUptd["name"] = `"test2"`
+	rsUptd["query"] = `"query2"`
+	updCfg := fmtTestConfigResource("view", "new", nilLst, rsUptd, chArgs)
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: iniCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testViewExists("logdna_view.new"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "test"),
+					resource.TestCheckResourceAttr("logdna_view.new", "apps.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", "app1"),
+					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", "app2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.0", "DemoCategory1"), // This value on the server is mixed case
+					resource.TestCheckResourceAttr("logdna_view.new", "categories.1", "DemoCategory2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "hosts.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", "host1"),
+					resource.TestCheckResourceAttr("logdna_view.new", "hosts.1", "host2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "levels.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "levels.0", "fatal"),
+					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", "critical"),
+					resource.TestCheckResourceAttr("logdna_view.new", "tags.#", "2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "tags.0", "tags1"),
+					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", "tags2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.#", "1"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.#", "1"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.emails.0", "test@logdna.com"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.immediate", "false"),
@@ -564,12 +425,6 @@ func TestViewMultipleChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.timezone", "Pacific/Samoa"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerinterval", "15m"),
 					resource.TestCheckResourceAttr("logdna_view.new", "email_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", host1),
-					resource.TestCheckResourceAttr("logdna_view.new", "hosts.1", host2),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.0", levels1),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", levels2),
 					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.#", "1"),
 					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.0.%", "6"),
 					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.0.immediate", "false"),
@@ -578,14 +433,18 @@ func TestViewMultipleChannels(t *testing.T) {
 					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.0.terminal", "true"),
 					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.0.triggerinterval", "15m"),
 					resource.TestCheckResourceAttr("logdna_view.new", "pagerduty_channel.0.triggerlimit", "15"),
-					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", levels2),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.#", "2"),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.0", tags1),
-					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", tags2),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.#", "1"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.%", "6"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.immediate", "false"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.operator", "absence"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.terminal", "true"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.triggerinterval", "30m"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.triggerlimit", "15"),
+					resource.TestCheckResourceAttr("logdna_view.new", "slack_channel.0.url", "https://hooks.slack.com/services/identifier/secret"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.#", "1"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.%", "9"),
 					// The JSON will have newlines per our API which uses JSON.stringify(obj, null, 2) as the value
-					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert From {{ name }}\"\n  }\n}"),
+					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.bodytemplate", "{\n  \"fields\": {\n    \"description\": \"{{ matches }} matches found for {{ name }}\",\n    \"issuetype\": {\n      \"name\": \"Bug\"\n    },\n    \"project\": {\n      \"key\": \"test\"\n    },\n    \"summary\": \"Alert from {{ name }}\"\n  }\n}"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.headers.%", "2"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.headers.hello", "test3"),
 					resource.TestCheckResourceAttr("logdna_view.new", "webhook_channel.0.headers.test", "test2"),
@@ -599,442 +458,28 @@ func TestViewMultipleChannels(t *testing.T) {
 				),
 			},
 			{
+				Config: updCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testViewExists("logdna_view.new"),
+					resource.TestCheckResourceAttr("logdna_view.new", "name", "test2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "query", "query2"),
+					resource.TestCheckResourceAttr("logdna_view.new", "apps.0", "app3"),
+					resource.TestCheckResourceAttr("logdna_view.new", "apps.1", "app4"),
+					resource.TestCheckResourceAttr("logdna_view.new", "hosts.0", "host3"),
+					resource.TestCheckResourceAttr("logdna_view.new", "hosts.1", "host4"),
+					resource.TestCheckResourceAttr("logdna_view.new", "levels.0", "error"),
+					resource.TestCheckResourceAttr("logdna_view.new", "levels.1", "warning"),
+					resource.TestCheckResourceAttr("logdna_view.new", "tags.0", "tags3"),
+					resource.TestCheckResourceAttr("logdna_view.new", "tags.1", "tags4"),
+				),
+			},
+			{
 				ResourceName:      "logdna_view.new",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
-}
-
-func testViewInvalidURL() string {
-	return fmt.Sprintf(`provider "logdna" {
-		url = "http://api.logdna.co"
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-	  }`, serviceKey)
-}
-
-func testViewConfigMultipleChannelsInvalidJSON() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		email_channel {
-		  emails          = ["test@logdna.com"]
-		  immediate       = "false"
-		  operator        = "absence"
-		  terminal        = "true"
-		  timezone        = "Pacific/Samoa"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-		pagerduty_channel {
-		  immediate       = "false"
-		  key             = "Your PagerDuty API key goes here"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  bodytemplate = "{\"test\": }"
-		  immediate       = "false"
-		  method          = "post"
-		  url             = "https://yourwebhook/endpoint"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey)
-}
-
-func testViewConfigTriggerIntervalError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-      }
-
-      resource "logdna_view" "new" {
-        name = "test"
-        query = "test"
-        email_channel {
-          emails          = ["test@logdna.com"]
-          immediate       = "false"
-          operator        = "absence"
-          terminal        = "true"
-          timezone        = "Pacific/Samoa"
-          triggerinterval = "17m"
-          triggerlimit    = 15
-        }
-      }`, serviceKey)
-}
-
-func testViewConfigImmediateError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-      }
-
-      resource "logdna_view" "new" {
-        name = "test"
-        query = "test"
-        email_channel {
-          emails          = ["test@logdna.com"]
-          immediate       = "no"
-          operator        = "absence"
-          terminal        = "true"
-          timezone        = "Pacific/Samoa"
-          triggerinterval = "15m"
-          triggerlimit    = 15
-        }
-      }`, serviceKey)
-}
-
-func testViewConfigURLError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  immediate       = "false"
-		  method          = "post"
-		  url             = "this is not a valid url"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey)
-}
-
-func testViewConfigMethodError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  immediate       = "false"
-		  method          = "false"
-		  url             = "http://yourwebhook/test"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey)
-}
-
-func testViewConfigServiceKeyError() string {
-	return `provider "logdna" {
-	}
-
-	resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-	}`
-}
-
-func testViewConfigNameError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		query = "test"
-	}`, serviceKey)
-}
-
-func testViewConfigAppsError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		apps = "test"
-	}`, serviceKey)
-}
-
-func testViewConfigCategoriesError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		categories = "test"
-	}`, serviceKey)
-}
-
-func testViewConfigHostsError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		hosts = "test"
-	}`, serviceKey)
-}
-
-func testViewConfigLevelsError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		levels = "test"
-	}`, serviceKey)
-}
-
-func testViewConfigTagsError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name = "test"
-		query = "test"
-		tags = "test"
-	}`, serviceKey)
-}
-
-func testViewConfigEmailTriggerLimitError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name     = "test"
-		query    = "test"
-		email_channel {
-			emails          = ["test@logdna.com"]
-			immediate       = "false"
-			operator        = "absence"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 0
-			timezone        = "Pacific/Samoa"
-		}
-	}`, serviceKey)
-}
-
-func testViewConfigPagerDutyTriggerLimitError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name     = "test"
-		query    = "test"
-		pagerduty_channel {
-			immediate       = "false"
-			key             = "Your PagerDuty API key goes here"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 0
-		}
-	}`, serviceKey)
-}
-
-func testViewConfigWebhookTriggerLimitError() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name     = "test"
-		query    = "test"
-		webhook_channel {
-			headers = {
-			  hello = "test3"
-			  test  = "test2"
-			}
-			immediate       = "false"
-			method          = "post"
-			url             = "https://yourwebhook/endpoint"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 0
-		}
-	}`, serviceKey)
-}
-
-func testViewConfigMissingEmails() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name     = "test"
-		query    = "test"
-		email_channel {
-			immediate       = "false"
-			operator        = "absence"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-			timezone        = "Pacific/Samoa"
-		}
-	}`, serviceKey)
-}
-
-func testViewConfigMissingKey() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name     = "test"
-		query    = "test"
-		pagerduty_channel {
-			immediate       = "false"
-			terminal        = "true"
-			triggerinterval = "15m"
-			triggerlimit    = 15
-		}
-	}`, serviceKey)
-}
-
-func testViewConfigMissingURL() string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-	resource "logdna_view" "new" {
-		name     = "test"
-		query    = "test"
-		webhook_channel {
-			triggerlimit = 15
-		}
-	}`, serviceKey)
-}
-
-func testViewConfigBasic(name, query string) string {
-	return fmt.Sprintf(`provider "logdna" {
-			servicekey = "%s"
-		}
-
-	resource "logdna_view" "new" {
-		name     = "%s"
-		query    = "%s"
-	}`, serviceKey, name, query)
-}
-
-func testViewConfigBulkEmails(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2 string) string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	}
-
-  resource "logdna_view" "new" {
-	name     = "%s"
-	query    = "%s"
-	apps     = ["%s", "%s"]
-	levels   = ["%s", "%s"]
-	hosts    = ["%s", "%s"]
-	categories = ["%s", "%s"]
-	tags     = ["%s", "%s"]
-	email_channel {
-	  emails          = ["test@logdna.com"]
-	  immediate       = "false"
-	  operator        = "absence"
-	  terminal        = "true"
-	  triggerinterval = "15m"
-	  triggerlimit    = 15
-	  timezone        = "Pacific/Samoa"
-	}
-	email_channel {
-	  emails          = ["test@logdna.com"]
-	  immediate       = "false"
-	  operator        = "absence"
-	  terminal        = "true"
-	  timezone        = "Pacific/Samoa"
-	  triggerlimit    = 15
-	  triggerinterval = "15m"
-	}
-  }`, serviceKey, name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2)
-}
-
-func testViewConfigMultipleChannels(name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2 string) string {
-	return fmt.Sprintf(`provider "logdna" {
-		servicekey = "%s"
-	  }
-
-	  resource "logdna_view" "new" {
-		name     = "%s"
-		query    = "%s"
-		apps     = ["%s", "%s"]
-		levels   = ["%s", "%s"]
-		hosts    = ["%s", "%s"]
-		categories = ["%s", "%s"]
-		tags     = ["%s", "%s"]
-		email_channel {
-		  emails          = ["test@logdna.com"]
-		  immediate       = "false"
-		  operator        = "absence"
-		  terminal        = "true"
-		  timezone        = "Pacific/Samoa"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-		pagerduty_channel {
-		  immediate       = "false"
-		  key             = "Your PagerDuty API key goes here"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-		webhook_channel {
-		  headers = {
-			hello = "test3"
-			test  = "test2"
-		  }
-		  bodytemplate = jsonencode({
-			fields = {
-				description = "{{ matches }} matches found for {{ name }}"
-				issuetype = {
-					name = "Bug"
-				}
-				project = {
-					key = "test"
-				},
-				summary = "Alert From {{ name }}"
-		   }
-		  })
-		  immediate       = "false"
-		  method          = "post"
-		  url             = "https://yourwebhook/endpoint"
-		  terminal        = "true"
-		  triggerinterval = "15m"
-		  triggerlimit    = 15
-		}
-	  }`, serviceKey, name, query, app1, app2, levels1, levels2, host1, host2, category1, category2, tags1, tags2)
 }
 
 func testViewExists(n string) resource.TestCheckFunc {

--- a/logdna/response_types.go
+++ b/logdna/response_types.go
@@ -93,6 +93,7 @@ func mapAllChannelsToSchema(
 	channelIntegrations := map[string][]interface{}{
 		EMAIL:     make([]interface{}, 0),
 		PAGERDUTY: make([]interface{}, 0),
+		SLACK:     make([]interface{}, 0),
 		WEBHOOK:   make([]interface{}, 0),
 	}
 
@@ -108,6 +109,8 @@ func mapAllChannelsToSchema(
 			prepared = mapChannelEmail(&c)
 		case PAGERDUTY:
 			prepared = mapChannelPagerDuty(&c)
+		case SLACK:
+			prepared = mapChannelSlack(&c)
 		case WEBHOOK:
 			prepared = mapChannelWebhook(&c)
 		default:
@@ -151,6 +154,19 @@ func mapChannelPagerDuty(channel *channelResponse) map[string]interface{} {
 	c["terminal"] = strconv.FormatBool(channel.Terminal)
 	c["triggerlimit"] = channel.TriggerLimit
 	c["triggerinterval"] = channel.TriggerInterval
+
+	return c
+}
+
+func mapChannelSlack(channel *channelResponse) map[string]interface{} {
+	c := make(map[string]interface{})
+
+	c["immediate"] = strconv.FormatBool(channel.Immediate)
+	c["operator"] = channel.Operator
+	c["terminal"] = strconv.FormatBool(channel.Terminal)
+	c["triggerlimit"] = channel.TriggerLimit
+	c["triggerinterval"] = channel.TriggerInterval
+	c["url"] = channel.URL
 
 	return c
 }

--- a/logdna/response_types_test.go
+++ b/logdna/response_types_test.go
@@ -20,6 +20,7 @@ func TestResponseTypes_mapAllChannelsToSchema(t *testing.T) {
 		expected := map[string][]interface{}{
 			EMAIL:     make([]interface{}, 0),
 			PAGERDUTY: make([]interface{}, 0),
+			SLACK:     make([]interface{}, 0),
 			WEBHOOK:   make([]interface{}, 0),
 		}
 		assert.Equal(expected, channelIntegrations, "Nothing was returned")


### PR DESCRIPTION
Defines the `slack_channel` argument in the schemas for resources
`logdna_alert` + `logdna_view` and the data source `logdna_alert`.
This facilitates the ability to integrate preset alerts and view-
specific alerts with Slack. Updated the tests accordingly and did
quite a bit of housecleaning to modularize & dedupe some code.

Ref: LOG-10589