### PR TITLE
feat: add indexonly option to exclusion rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage
 dist
 .vscode
+.idea
 *.asc

--- a/docs/resources/logdna_ingestion_exclusion.md
+++ b/docs/resources/logdna_ingestion_exclusion.md
@@ -16,6 +16,7 @@ resource "logdna_ingestion_exclusion" "http-success" {
   apps   = ["nginx", "apache"]
   query  = "response:(>=200 <300)"
   active = true
+  indexonly = false
 }
 
 resource "logdna_ingestion_exclusion" "http-noise" {
@@ -23,6 +24,7 @@ resource "logdna_ingestion_exclusion" "http-noise" {
   apps   = ["nginx", "apache"]
   query  = "robots.txt OR favicon.ico OR .well-known"
   active = true
+  indexonly = true
 }
 ```
 
@@ -34,6 +36,7 @@ _Note:_ A `title` and at least one of the following properties: `apps`, `hosts`,
 
 - `title`: **string** _(Optional)_ Title of this exclusion rule that will appear in the UI.
 - `active`: **_bool_** _(Optional; Default: false)_ Whether the rule should be active.
+- `indexonly`: **_bool_** _(Optional; Default: true)_ Live-tail and alerting will be preserved when `true`.
 - `apps`: **_[]string_** _(Optional)_ Array of app names to exclude.
 - `hosts`: **_[]string_** _(Optional)_ Array of hosts to exclude.
 - `query`: **_string_** _(Optional)_ A search query to match lines to exclude

--- a/examples/ingestion_exclusions.tf
+++ b/examples/ingestion_exclusions.tf
@@ -7,6 +7,7 @@ resource "logdna_ingestion_exclusion" "http-success" {
   apps   = ["nginx", "apache"]
   query  = "response:(>=200 <300)"
   active = true
+  indexonly = false
 }
 
 resource "logdna_ingestion_exclusion" "http-noise" {
@@ -14,4 +15,5 @@ resource "logdna_ingestion_exclusion" "http-noise" {
   apps   = ["nginx", "apache"]
   query  = "robots.txt OR favicon.ico OR .well-known"
   active = true
+  indexonly = true
 }

--- a/logdna/ingestion_exclusion_rule.go
+++ b/logdna/ingestion_exclusion_rule.go
@@ -1,0 +1,56 @@
+package logdna
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+type ingestionExclusionRule struct {
+	ID        string   `json:"id,omitempty"`
+	Title     string   `json:"title"`
+	Active    bool     `json:"active"`
+	IndexOnly bool     `json:"indexonly"`
+	Apps      []string `json:"apps"`
+	Hosts     []string `json:"hosts"`
+	Query     string   `json:"query"`
+}
+
+var ingestionExclusionRuleAtLeastOneOfFields = []string{"apps", "hosts", "query"}
+
+var ingestionExclusionRuleSchema = map[string]*schema.Schema{
+	"id": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+	"title": {
+		Type:     schema.TypeString,
+		Default:  nil,
+		Optional: true,
+	},
+	"active": {
+		Type:     schema.TypeBool,
+		Default:  false,
+		Optional: true,
+	},
+	"indexonly": {
+		Type:     schema.TypeBool,
+		Default:  true,
+		Optional: true,
+	},
+	"apps": {
+		Type:         schema.TypeList,
+		Elem:         &schema.Schema{Type: schema.TypeString},
+		MinItems:     1,
+		Optional:     true,
+		AtLeastOneOf: ingestionExclusionRuleAtLeastOneOfFields,
+	},
+	"hosts": {
+		Type:         schema.TypeList,
+		Elem:         &schema.Schema{Type: schema.TypeString},
+		MinItems:     1,
+		Optional:     true,
+		AtLeastOneOf: ingestionExclusionRuleAtLeastOneOfFields,
+	},
+	"query": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		AtLeastOneOf: ingestionExclusionRuleAtLeastOneOfFields,
+	},
+}

--- a/logdna/resource_ingestion_exclusion.go
+++ b/logdna/resource_ingestion_exclusion.go
@@ -15,12 +15,13 @@ func resourceIngestionExclusionCreate(ctx context.Context, d *schema.ResourceDat
 	var diags diag.Diagnostics
 
 	pc := m.(*providerConfig)
-	ex := exclusionRule{
-		Title:  d.Get("title").(string),
-		Active: d.Get("active").(bool),
-		Apps:   listToStrings(d.Get("apps").([]interface{})),
-		Hosts:  listToStrings(d.Get("hosts").([]interface{})),
-		Query:  d.Get("query").(string),
+	ex := ingestionExclusionRule{
+		Title:     d.Get("title").(string),
+		Active:    d.Get("active").(bool),
+		IndexOnly: d.Get("indexonly").(bool),
+		Apps:      listToStrings(d.Get("apps").([]interface{})),
+		Hosts:     listToStrings(d.Get("hosts").([]interface{})),
+		Query:     d.Get("query").(string),
 	}
 
 	req := newRequestConfig(
@@ -35,7 +36,7 @@ func resourceIngestionExclusionCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 
-	exn := exclusionRule{}
+	exn := ingestionExclusionRule{}
 	err = json.Unmarshal(body, &exn)
 	if err != nil {
 		return diag.FromErr(err)
@@ -72,7 +73,7 @@ func resourceIngestionExclusionRead(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 
-	ex := exclusionRule{}
+	ex := ingestionExclusionRule{}
 	err = json.Unmarshal(body, &ex)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
@@ -85,6 +86,7 @@ func resourceIngestionExclusionRead(ctx context.Context, d *schema.ResourceData,
 
 	appendError(d.Set("title", ex.Title), &diags)
 	appendError(d.Set("active", ex.Active), &diags)
+	appendError(d.Set("indexonly", ex.IndexOnly), &diags)
 	appendError(d.Set("apps", ex.Apps), &diags)
 	appendError(d.Set("hosts", ex.Hosts), &diags)
 	appendError(d.Set("query", ex.Query), &diags)
@@ -94,12 +96,13 @@ func resourceIngestionExclusionRead(ctx context.Context, d *schema.ResourceData,
 
 func resourceIngestionExclusionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	pc := m.(*providerConfig)
-	ex := exclusionRule{
-		Title:  d.Get("title").(string),
-		Active: d.Get("active").(bool),
-		Apps:   listToStrings(d.Get("apps").([]interface{})),
-		Hosts:  listToStrings(d.Get("hosts").([]interface{})),
-		Query:  d.Get("query").(string),
+	ex := ingestionExclusionRule{
+		Title:     d.Get("title").(string),
+		Active:    d.Get("active").(bool),
+		IndexOnly: d.Get("indexonly").(bool),
+		Apps:      listToStrings(d.Get("apps").([]interface{})),
+		Hosts:     listToStrings(d.Get("hosts").([]interface{})),
+		Query:     d.Get("query").(string),
 	}
 
 	req := newRequestConfig(
@@ -145,6 +148,6 @@ func resourceIngestionExclusion() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: exclusionRuleSchema,
+		Schema: ingestionExclusionRuleSchema,
 	}
 }

--- a/logdna/resource_ingestion_exclusion_test.go
+++ b/logdna/resource_ingestion_exclusion_test.go
@@ -52,6 +52,7 @@ func TestIngestionExclusion_basic(t *testing.T) {
 				Config: testIngestionExclusion(`
 					title = "test-title"
 					active = true
+					indexonly = true
 					apps = [
 						"app-1",
 						"app-2"
@@ -66,6 +67,7 @@ func TestIngestionExclusion_basic(t *testing.T) {
 					testResourceExists("ingestion_exclusion", "new"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "title", "test-title"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "active", "true"),
+					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "indexonly", "true"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "apps.#", "2"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "apps.0", "app-1"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "apps.1", "app-2"),
@@ -79,6 +81,7 @@ func TestIngestionExclusion_basic(t *testing.T) {
 				Config: testIngestionExclusion(`
 					title = "test-title-update"
 					active = false
+					indexonly = false
 					apps = [
 						"app-1",
 						"app-2"
@@ -93,6 +96,7 @@ func TestIngestionExclusion_basic(t *testing.T) {
 					testResourceExists("ingestion_exclusion", "new"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "title", "test-title-update"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "active", "false"),
+					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "indexonly", "false"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "apps.#", "2"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "hosts.#", "2"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "query", "foo bar"),
@@ -111,6 +115,8 @@ func TestIngestionExclusion_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testResourceExists("ingestion_exclusion", "new"),
 					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "hosts.#", "0"),
+					// `indexonly` should default to `true`
+					resource.TestCheckResourceAttr("logdna_ingestion_exclusion.new", "indexonly", "true"),
 				),
 			},
 			{


### PR DESCRIPTION
This change adds support for the index only option when creating and updating ingestion exclusion rules.

Ref: LOG-14612