### PR TITLE
fix: set request content-type based on payload

### DIFF
--- a/logdna/request.go
+++ b/logdna/request.go
@@ -61,7 +61,7 @@ func (c *requestConfig) MakeRequest() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if c.method != http.MethodDelete {
+	if payloadBuf.Len() > 0 {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("servicekey", c.serviceKey)


### PR DESCRIPTION
Only set the "Content-Type" of a request to "application/json" only if the request includes a body. This ensures the "Content-Type" is appropriate for the request and is interpretted correctly by the API.

Signed-off-by: Jacob Hull <jacob@planethull.com>