### PR TITLE
docs(alerts): clarify immedaite/terminal and add slack_channel to views

### DIFF
--- a/docs/resources/logdna_alert.md
+++ b/docs/resources/logdna_alert.md
@@ -121,9 +121,9 @@ The following arguments are supported by `logdna_alert`:
 `email_channel` supports the following arguments:
 
 - `emails`: **_[]string (Required)_** An array of email addresses (strings) to notify in the Alert
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `timezone`: **_string_** _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
@@ -132,10 +132,10 @@ The following arguments are supported by `logdna_alert`:
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `key`: **_string (Required)_** The PagerDuty service key.
 - `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 - `autoresolve`: **_boolean_** Set to true if you want the set a condition to resolve the incident that was raised by this alert.
@@ -146,9 +146,9 @@ The following arguments are supported by `logdna_alert`:
 
 `slack_channel` supports the following arguments:
 
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 - `url`: **_string (Required)_** The URL of the webhook for a given Slack application/integration (& channel).
@@ -159,10 +159,10 @@ The following arguments are supported by `logdna_alert`:
 
 - `bodytemplate`: **_string_** _(Optional)_ JSON-formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string.
 - `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request headers and header values. Example: `"MyHeader" = "MyValue"`
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
 - `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 - `url`: **_string (Required)_** The URL of the webhook.

--- a/docs/resources/logdna_view.md
+++ b/docs/resources/logdna_view.md
@@ -73,6 +73,15 @@ resource "logdna_view" "my_view" {
     triggerlimit    = 15
   }
 
+  slack_channel {
+    immediate       = "false"
+    operator        = "absence"
+    terminal        = "true"
+    triggerinterval = "15m"
+    triggerlimit    = 15
+    url             = "https://hooks.slack.com/services/identifier/secret"
+  }
+
   webhook_channel {
     bodytemplate = jsonencode({
       message = "Alerts from {{name}}"
@@ -124,9 +133,9 @@ _Note:_ Any of `*_channel` parameters are not allowed if a `presetid` parameter 
 `email_channel` supports the following arguments:
 
 - `emails`: **[]string _(Required)_** An array of email addresses (strings) to notify in the Alert
-- `immediate`: **string** _(Optional; Default: `"false"`)_ Whether the Alert will be triggered immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `operator`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g., send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `timezone`: **string** _(Optional)_ Which time zone the log timestamps will be formatted in. Timezones are represented as [database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
@@ -135,15 +144,26 @@ _Note:_ Any of `*_channel` parameters are not allowed if a `presetid` parameter 
 
 `pagerduty_channel` supports the following arguments:
 
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will be triggered immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts, and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `key`: **string _(Required)_** The service key used for PagerDuty.
 - `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
 - `autoresolve`: **_boolean_** Set to true if you want the set a condition to resolve the incident that was raised by this alert.
 - `autoresolveinterval`: **_string_** _(Required if autoresolve is set to true)_ Interval of time to aggregate and check # of matched lines against the auto resolve limit. Valid values are: 30 seconds, 1 minute, 5 minutes, 15 minutes, 30 minutes, 1 hour, 6 hours, 12 hours, 24 hours.
 - `autoresolvelimit`: **_integer_** _(Required if autoresolve is set to true)_ Specify the number of log lines that match the view's filtering and search criteria. When the number of log lines is reached, this incident will be set to resolved in PagerDuty.
+
+### slack_channel
+
+`slack_channel` supports the following arguments:
+
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
+- `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
+- `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
+- `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered (e.g. setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`).
+- `url`: **_string (Required)_** The URL of the webhook for a given Slack application/integration (& channel).
 
 ### webhook_channel
 
@@ -151,10 +171,10 @@ _Note:_ Any of `*_channel` parameters are not allowed if a `presetid` parameter 
 
 - `bodytemplate`: **string** _(Optional)_ JSON-formatted string for the body of the webhook. We recommend using [`jsonencode()`](https://www.terraform.io/docs/configuration/functions/jsonencode.html) to easily convert a Terraform map into a JSON string.
 - `headers`: **_map<string, string>** _(Optional)_ Key-value pair for webhook request headers and header values. Example: `"MyHeader" = "MyValue"`
-- `immediate`: **_string_** _(Optional; Default: `"false"`)_ Whether the Alert will trigger immediately after the trigger limit is reached. Valid options are `"true"` and `"false"` for presence Alerts, and `"false"` for absence Alerts.
+- `immediate`: **_string_** _(Optional; Default: `"false"`)_ If set to `"true"`, an alert will be sent immediately after the `triggerlimit` is met. For absence alerts, this field must be `"false"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `method`: **_string_** _(Optional; Default: `post`)_ Method used for the webhook request. Valid options are: `post`, `put`, `patch`, `get`, `delete`.
 - `operator`: **_string_** _(Optional; Default: `presence`)_ Whether the Alert will trigger on the presence or absence of logs. Valid options are `presence` and `absence`.
-- `terminal`: **_string_** _(Optional; Default: `"true"`)_ Whether the Alert will trigger after the `triggerinterval` if the Alert condition is met (e.g. send an Alert after 30s). Valid options are `"true"` and `"false"` for presence Alerts, and `"true"` for absence Alerts.
+- `terminal`: **_string_** _(Optional; Default: `"true"`)_ If set to `"true"`, an alert will be sent after both the `triggerlimit` and `triggerinterval` are met. For absence alerts, this field must be `"true"`. For presence alerts, at least one of `immediate` or `terminal` must be `"true"`.
 - `triggerinterval`: **_string_** _(Optional; Defaults: `"30"` for presence; `"15m"` for absence)_ Interval which the Alert will be looking for presence or absence of log lines. For presence Alerts, valid options are: `30`, `1m`, `5m`, `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`. For absence Alerts, valid options are: `15m`, `30m`, `1h`, `6h`, `12h`, `24h`, and `25h`.
 - `triggerlimit`: **_integer (Required)_** Number of lines before the Alert is triggered. (eg. Setting a value of `10` for an `absence` Alert would alert you if `10` lines were not seen in the `triggerinterval`)
 - `url`: **_string (Required)_** The URL of the webhook.


### PR DESCRIPTION
Clarifies description for both the `immediate` and `terminal` fields to make it clear at least one of them are required to be true for presence alerts. Fixes #105.

Update the view resource documentation with the `slack_channel`. Fixes #85.