### PR TITLE
feat(request): Add support for new http authorization scheme

### DIFF
--- a/logdna/request.go
+++ b/logdna/request.go
@@ -6,7 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 )
+
+var platformTokenPrefixExp, _ = regexp.Compile("^st[a-z]_[0-9a-f]{40}$")
 
 type httpRequest func(string, string, io.Reader) (*http.Request, error)
 type bodyReader func(io.Reader) ([]byte, error)
@@ -72,7 +75,11 @@ func (c *requestConfig) MakeRequest() ([]byte, error) {
 	// Set the correct authorization headers depending on what has been passed in
 	// the provider config
 	if c.serviceKey != "" {
-		req.Header.Set("servicekey", c.serviceKey)
+		if platformTokenPrefixExp.MatchString(c.serviceKey) {
+			req.Header.Set("Authorization", "Token "+c.serviceKey)
+		} else {
+			req.Header.Set("servicekey", c.serviceKey)
+		}
 	} else if c.iamtoken != "" && c.cloud_resource_name != "" {
 		req.Header.Set("Authorization", "Bearer "+c.iamtoken)
 		req.Header.Set("cloud-resource-name", c.cloud_resource_name)

--- a/logdna/request_test.go
+++ b/logdna/request_test.go
@@ -158,6 +158,33 @@ func TestRequest_MakeRequest(t *testing.T) {
 		)
 	})
 
+	t.Run("Successfully sends request using platform iam token", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewEncoder(w).Encode(viewResponse{ViewID: "test123456"})
+			assert.Nil(err, "No errors")
+		}))
+		defer ts.Close()
+
+		pc.baseURL = ts.URL
+		tempServicKey := pc.serviceKey
+		pc.serviceKey = "sta_c0a6c93abc6033c838be48964454f8d6bc4eb120"
+
+		req := newRequestConfig(
+			&pc,
+			"GET",
+			fmt.Sprintf("/some-other/api/%s", resourceID),
+			nil,
+		)
+		pc.serviceKey = tempServicKey
+		body, err := req.MakeRequest()
+		assert.Nil(err, "No errors")
+		assert.Equal(
+			`{"viewID":"test123456"}`,
+			strings.TrimSpace(string(body)),
+			"Returned body is correct",
+		)
+	})
+
 	t.Run("Reads and decodes response from the server, iamtoken", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			err := json.NewEncoder(w).Encode(viewResponse{ViewID: "test123456"})


### PR DESCRIPTION
Given a serviceKey with the format ^st[a-z]_ set the auth scheme to Token in the authorization header. This will allow people to continue to tuse this provider with new platform iam tokens

Ref: LOG-22014