### PR TITLE
fix(ci): always publish a release on merge

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,6 @@ checksum:
 signs:
   - artifacts: checksum
 release:
-  draft: true # Require manual release publishing
+  draft: false # It seems now that making it a draft will prevent the release from ever being picked up from terraform
 changelog:
   disable: true


### PR DESCRIPTION
At some point it would seem that publishing a tag as a draft results in the terraform registry
web hooks to always be rejects with the message - "ignoring draft release"

We are disabling this in an effort to trigger a release before attempting a manual publish